### PR TITLE
Update exercise videos and add start time support

### DIFF
--- a/app.js
+++ b/app.js
@@ -121,7 +121,7 @@ function render() {
       <div class="exercise" data-index="${index}">
         <div class="exercise-header">
           <span class="exercise-name">${ex.name}</span>
-          ${ex.video_id ? `<button class="video-btn" data-video="${ex.video_id}">VIDEO</button>` : '<button class="video-btn" disabled>NO VIDEO</button>'}
+          ${ex.video_id ? `<button class="video-btn" data-video="${ex.video_id}" data-start="${ex.video_start || 0}">VIDEO</button>` : '<button class="video-btn" disabled>NO VIDEO</button>'}
         </div>
         <div class="exercise-details">
           <span><strong>${ex.sets}</strong> sets</span>
@@ -171,7 +171,7 @@ function bindEvents() {
   // Video buttons (delegated)
   document.getElementById('exercises-list').addEventListener('click', (e) => {
     if (e.target.classList.contains('video-btn') && !e.target.disabled) {
-      openVideo(e.target.dataset.video);
+      openVideo(e.target.dataset.video, e.target.dataset.start);
     }
   });
 
@@ -249,13 +249,15 @@ function resetProgress() {
 }
 
 // Open video modal
-function openVideo(videoId) {
+function openVideo(videoId, startTime) {
   const modal = document.getElementById('video-modal');
   const container = document.getElementById('video-container');
+  const start = parseInt(startTime) || 0;
+  const startParam = start > 0 ? `&start=${start}` : '';
 
   container.innerHTML = `
     <iframe
-      src="https://www.youtube.com/embed/${videoId}?autoplay=1&rel=0"
+      src="https://www.youtube.com/embed/${videoId}?autoplay=1&rel=0${startParam}"
       allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
       allowfullscreen>
     </iframe>

--- a/data/program.json
+++ b/data/program.json
@@ -33,7 +33,7 @@
               "sets": 2,
               "reps": "15",
               "rest": "0s",
-              "video_id": "JObTUaX9sg8",
+              "video_id": "MnDpmNYUjbc",
               "note": "Light band. Squeeze shoulder blades together at end range."
             },
             {
@@ -41,7 +41,7 @@
               "sets": 2,
               "reps": "10/direction",
               "rest": "0s",
-              "video_id": "bLBMHP8iybo",
+              "video_id": "altA7815AGs",
               "note": "Controlled circles, both directions. Open up the hip capsule."
             },
             {
@@ -57,7 +57,7 @@
               "sets": 3,
               "reps": "12/side",
               "rest": "90s",
-              "video_id": "7YxeAEvl7m4",
+              "video_id": "Z44y6AgV-TI",
               "note": "Keep lower back flat. Use the 10lb DB if KB is too heavy initially."
             },
             {
@@ -65,16 +65,17 @@
               "sets": 4,
               "reps": "15",
               "rest": "90s",
-              "video_id": "SgZf7NYWFkc",
+              "video_id": "1cVT3ee9mgU",
+              "video_start": 9,
               "note": "Hinge only. Squeeze glutes at top. No lower back rounding."
             },
             {
-              "name": "Ladder Inverted Rows",
+              "name": "TRX Inverted Rows",
               "sets": 3,
               "reps": "8-12",
               "rest": "90s",
-              "video_id": "11F_O_sZ1Z4",
-              "note": "Adjust rung height to change difficulty. Stop 1-2 reps before form breaks down."
+              "video_id": "ypIQZWKMbkU",
+              "note": "Adjust strap length to change difficulty. Stop 1-2 reps before form breaks down."
             }
           ]
         },


### PR DESCRIPTION
## Summary
- Updated 5 exercise video links with user-selected tutorials
- Added support for video start times (videos can begin at a specific timestamp)
- Renamed "Ladder Inverted Rows" to "TRX Inverted Rows" to match available equipment

## Video Changes

| Exercise | New Video ID | Notes |
|----------|--------------|-------|
| Band Pull-Aparts | `MnDpmNYUjbc` | |
| Hip Circles | `altA7815AGs` | |
| KB Gorilla Rows | `Z44y6AgV-TI` | |
| Kettlebell Swings | `1cVT3ee9mgU` | Starts at 9s |
| TRX Inverted Rows | `ypIQZWKMbkU` | Renamed from Ladder Inverted Rows |

## New Feature: video_start

Exercises can now include an optional `video_start` field (in seconds) to skip intros:

```json
{
  "name": "Kettlebell Swings",
  "video_id": "1cVT3ee9mgU",
  "video_start": 9
}
```

## Test plan
- [ ] Verify all video links load correctly
- [ ] Confirm Kettlebell Swings video starts at ~9 seconds
- [ ] Check TRX Inverted Rows note reflects strap-based setup