### PR TITLE
Improve text readability with larger fonts and brighter colors

### DIFF
--- a/style.css
+++ b/style.css
@@ -5,9 +5,9 @@
   --bg-secondary: #111111;
   --bg-card: #1a1a1a;
   --accent: #00ff88;
-  --accent-dim: #00cc6a;
+  --accent-dim: #00dd77;
   --text-primary: #e0e0e0;
-  --text-secondary: #888888;
+  --text-secondary: #aaaaaa;
   --danger: #ff4444;
   --border: #333333;
   --glow: 0 0 20px rgba(0, 255, 136, 0.3);
@@ -48,7 +48,7 @@ header h1 {
 }
 
 #day-counter {
-  font-size: 0.9rem;
+  font-size: 1rem;
   color: var(--text-secondary);
   margin-top: 0.5rem;
 }
@@ -81,13 +81,13 @@ main {
 }
 
 #workout-name {
-  font-size: 1.2rem;
+  font-size: 1.3rem;
   color: var(--accent);
   margin-bottom: 0.25rem;
 }
 
 #workout-focus {
-  font-size: 0.85rem;
+  font-size: 1rem;
   color: var(--text-secondary);
 }
 
@@ -108,7 +108,7 @@ main {
 }
 
 .exercise-name {
-  font-size: 1rem;
+  font-size: 1.1rem;
   font-weight: bold;
   color: var(--text-primary);
   flex: 1;
@@ -119,7 +119,7 @@ main {
   border: 1px solid var(--accent);
   color: var(--accent);
   padding: 0.25rem 0.5rem;
-  font-size: 0.75rem;
+  font-size: 0.9rem;
   border-radius: 4px;
   cursor: pointer;
   font-family: inherit;
@@ -139,7 +139,7 @@ main {
 .exercise-details {
   display: flex;
   gap: 1rem;
-  font-size: 0.85rem;
+  font-size: 1rem;
   color: var(--text-secondary);
   margin-bottom: 0.5rem;
 }
@@ -151,7 +151,7 @@ main {
 }
 
 .exercise-note {
-  font-size: 0.8rem;
+  font-size: 0.95rem;
   color: var(--accent-dim);
   font-style: italic;
   padding-top: 0.5rem;
@@ -169,7 +169,7 @@ main {
 }
 
 .weight-input label {
-  font-size: 0.8rem;
+  font-size: 0.95rem;
   color: var(--text-secondary);
 }
 
@@ -180,7 +180,7 @@ main {
   padding: 0.5rem;
   width: 80px;
   font-family: inherit;
-  font-size: 1rem;
+  font-size: 1.1rem;
   border-radius: 4px;
   text-align: center;
 }
@@ -192,7 +192,7 @@ main {
 }
 
 .weight-input .unit {
-  font-size: 0.8rem;
+  font-size: 0.95rem;
   color: var(--text-secondary);
 }
 
@@ -229,7 +229,7 @@ main {
 }
 
 .suggested-hint {
-  font-size: 0.75rem;
+  font-size: 0.9rem;
   color: var(--text-secondary);
   font-style: italic;
   margin-left: 0.5rem;
@@ -270,7 +270,7 @@ footer {
   color: var(--bg-primary);
   border: none;
   padding: 1rem;
-  font-size: 1rem;
+  font-size: 1.1rem;
   font-weight: bold;
   font-family: inherit;
   border-radius: 6px;
@@ -294,7 +294,7 @@ footer {
   border: 1px solid var(--border);
   color: var(--text-secondary);
   padding: 1rem;
-  font-size: 0.85rem;
+  font-size: 1rem;
   font-family: inherit;
   border-radius: 6px;
   cursor: pointer;


### PR DESCRIPTION
## Summary
- Increased minimum font size from 0.75rem to 0.9rem for better visibility
- Bumped mid-range font sizes (0.8-0.85rem) up to 0.95-1rem
- Brightened secondary text color from #888888 to #aaaaaa
- Brightened dim accent color from #00cc6a to #00dd77

## Test plan
- [ ] Open the app and verify text is more readable
- [ ] Check exercise names, details, and notes are visible
- [ ] Verify buttons and labels are easier to read
- [ ] Confirm the cyberpunk aesthetic is preserved