### PR TITLE
Start Hip Circles video at 9s

### DIFF
--- a/data/program.json
+++ b/data/program.json
@@ -43,6 +43,7 @@
               "reps": "10/direction",
               "rest": "0s",
               "video_id": "altA7815AGs",
+              "video_start": 9,
               "note": "Controlled circles, both directions. Open up the hip capsule.",
               "uses_weight": false
             },


### PR DESCRIPTION
## Summary

- Add `video_start: 9` to Hip Circles exercise to skip the intro

## Test plan

- [ ] Open Hip Circles video and verify it starts at 9 seconds