### PR TITLE
Fix manifest paths for GitHub Pages

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,18 +2,18 @@
   "name": "Basement Lab",
   "short_name": "Basement Lab",
   "description": "12 Month Transformation Tracker",
-  "start_url": "/",
+  "start_url": "/build/",
   "display": "standalone",
   "background_color": "#0a0a0a",
   "theme_color": "#0a0a0a",
   "icons": [
     {
-      "src": "data/icon-192.png",
+      "src": "/build/data/icon-192.png",
       "sizes": "192x192",
       "type": "image/png"
     },
     {
-      "src": "data/icon-512.png",
+      "src": "/build/data/icon-512.png",
       "sizes": "512x512",
       "type": "image/png"
     }


### PR DESCRIPTION
Fix start_url and icon paths to work on patflynn.github.io/build/