### PR TITLE
Auto-install npm deps in test shell hook

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -38,6 +38,7 @@
           shellHook = ''
             export PLAYWRIGHT_BROWSERS_PATH=${pkgs.playwright-driver.browsers}
             export PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
+            npm install --prefer-offline --no-audit --no-fund 2>/dev/null
             echo "Basement Lab test shell (with Playwright)"
           '';
         };


### PR DESCRIPTION
## Summary
- Adds `npm install --prefer-offline --no-audit --no-fund` to the `nix develop .#test` shell hook
- Ensures `@playwright/test` (and other npm devDependencies) are available without a manual install step

## Test plan
- [x] `rm -rf node_modules && nix develop .#test --command npm test` passes all 64 tests