### PR TITLE
Use --quiet instead of /dev/null for test shell npm install

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -38,7 +38,7 @@
           shellHook = ''
             export PLAYWRIGHT_BROWSERS_PATH=${pkgs.playwright-driver.browsers}
             export PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
-            npm install --prefer-offline --no-audit --no-fund 2>/dev/null
+            npm install --prefer-offline --no-audit --no-fund --quiet
             echo "Basement Lab test shell (with Playwright)"
           '';
         };


### PR DESCRIPTION
## Summary
- Replace `2>/dev/null` with `--quiet` on the npm install in the test shell hook
- Suppresses install summary noise while keeping real errors visible on stderr

## Test plan
- [x] `nix develop .#test` enters cleanly with minimal output