### PR TITLE
Add klaus to dev shell

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -18,6 +18,45 @@
         "type": "github"
       }
     },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "klaus": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1770949508,
+        "narHash": "sha256-HSnmKSgcBk6g+FzN3ZFHSTawMVG9phDswGdykqLqVnE=",
+        "owner": "patflynn",
+        "repo": "klaus",
+        "rev": "217b5ade007cbd659b0ad675811e5be24af781b1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "patflynn",
+        "repo": "klaus",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1770197578,
@@ -37,10 +76,26 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
+        "klaus": "klaus",
         "nixpkgs": "nixpkgs"
       }
     },
     "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -4,9 +4,13 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
+    klaus = {
+      url = "github:patflynn/klaus";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
-  outputs = { self, nixpkgs, flake-utils }:
+  outputs = { self, nixpkgs, flake-utils, klaus }:
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
@@ -17,6 +21,7 @@
             nodejs_20
             nodePackages.serve
             imagemagick
+            klaus.packages.${system}.default
           ];
 
           shellHook = ''


### PR DESCRIPTION
## Summary
- Adds `patflynn/klaus` as a flake input
- Makes `klaus` available in the nix dev shell for multi-agent orchestration

## Test plan
- [ ] `nix develop --command klaus --version` returns version