### PR TITLE
Fix timer widget layout on mobile viewports

### DIFF
--- a/style.css
+++ b/style.css
@@ -667,7 +667,7 @@ main {
   border: 1px solid var(--border);
   border-radius: 4px;
   padding: 0.4rem 0.6rem;
-  flex: 1;
+  flex: 1 1 14rem;
   min-width: 0;
 }
 

--- a/tests/e2e.spec.js
+++ b/tests/e2e.spec.js
@@ -613,6 +613,26 @@ test.describe('Basement Lab PWA', () => {
     await expect(restTimerLabel).toHaveCount(1);
   });
 
+  test('timer widgets do not overflow their container on small viewports', async ({ page }) => {
+    const timerSection = page.locator('.timer-section').first();
+    await timerSection.scrollIntoViewIfNeeded();
+
+    // Each timer widget should fit within the exercise card (no horizontal overflow)
+    const widgets = timerSection.locator('.timer-widget');
+    const count = await widgets.count();
+    expect(count).toBeGreaterThan(0);
+
+    for (let i = 0; i < count; i++) {
+      const widget = widgets.nth(i);
+      const box = await widget.boundingBox();
+      const sectionBox = await timerSection.boundingBox();
+      // Widget should not extend beyond the timer section's right edge
+      expect(box.x + box.width).toBeLessThanOrEqual(sectionBox.x + sectionBox.width + 1);
+      // Widget should have reasonable width (at least 200px on a 375px screen)
+      expect(box.width).toBeGreaterThan(200);
+    }
+  });
+
   test('each theme has distinct accent color', async ({ page }) => {
     const getAccentColor = async () => {
       const header = page.locator('header h1');


### PR DESCRIPTION
## Summary
- Fixed timer widgets overflowing on small screens (375px and below) by changing `flex: 1` to `flex: 1 1 14rem` on `.timer-widget`, so flex-wrap stacks them vertically on narrow viewports
- Added e2e test verifying timer widgets don't overflow their container and maintain reasonable width on mobile

## Test plan
- [x] All 84 existing e2e tests pass (chromium + mobile projects)
- [x] New overflow test passes on both desktop and 375x667 mobile viewport
- [x] Timer widgets stack vertically on small screens, remain side-by-side on wider viewports

Run: 20260307-1735-075b
Fixes #43