### PR TITLE
Add version/commit display to settings modal

### DIFF
--- a/app.js
+++ b/app.js
@@ -31,6 +31,23 @@ async function init() {
   migrateProfile();
   render();
   bindEvents();
+  loadVersion();
+}
+
+// Load version info from version.json (generated at build time)
+async function loadVersion() {
+  try {
+    const resp = await fetch('version.json');
+    if (!resp.ok) return;
+    const data = await resp.json();
+    const el = document.getElementById('version-info');
+    if (el && data.version) {
+      const commit = data.commit && data.commit !== 'dev' ? ` · ${data.commit}` : '';
+      el.textContent = `v${data.version}${commit}`;
+    }
+  } catch {
+    // version.json not available (local dev) — ignore
+  }
 }
 
 // Load profile from localStorage

--- a/app.js
+++ b/app.js
@@ -45,8 +45,8 @@ async function loadVersion() {
       const commit = data.commit && data.commit !== 'dev' ? ` · ${data.commit}` : '';
       el.textContent = `v${data.version}${commit}`;
     }
-  } catch {
-    // version.json not available (local dev) — ignore
+  } catch (error) {
+    console.warn('Could not load version info:', error);
   }
 }
 

--- a/flake.nix
+++ b/flake.nix
@@ -56,24 +56,29 @@
           '';
         };
 
-        packages.default = pkgs.stdenv.mkDerivation {
-          pname = "flux";
-          version = "1.0.0";
-          src = ./.;
+        packages.default =
+          let
+            commit = self.shortRev or self.dirtyShortRev or "dev";
+            ver = "1.0.0";
+            versionJSON = builtins.toJSON {
+              version = ver;
+              inherit commit;
+            };
+          in
+          pkgs.stdenv.mkDerivation {
+            pname = "flux";
+            version = ver;
+            src = ./.;
 
-          installPhase =
-            let
-              commit = self.shortRev or "dev";
-            in
-            ''
+            installPhase = ''
               mkdir -p $out
               for f in index.html style.css app.js timer.js manifest.json; do
                 cp $f $out/
               done
               cp -r data $out/
-              echo '{"version":"${version}","commit":"${commit}"}' > $out/version.json
+              echo '${versionJSON}' > $out/version.json
             '';
-        };
+          };
       }
     );
 }

--- a/flake.nix
+++ b/flake.nix
@@ -71,7 +71,7 @@
                 cp $f $out/
               done
               cp -r data $out/
-              echo '{"version":"1.0.0","commit":"${commit}"}' > $out/version.json
+              echo '{"version":"${version}","commit":"${commit}"}' > $out/version.json
             '';
         };
       }

--- a/flake.nix
+++ b/flake.nix
@@ -61,13 +61,18 @@
           version = "1.0.0";
           src = ./.;
 
-          installPhase = ''
-            mkdir -p $out
-            for f in index.html style.css app.js timer.js manifest.json; do
-              cp $f $out/
-            done
-            cp -r data $out/
-          '';
+          installPhase =
+            let
+              commit = self.shortRev or "dev";
+            in
+            ''
+              mkdir -p $out
+              for f in index.html style.css app.js timer.js manifest.json; do
+                cp $f $out/
+              done
+              cp -r data $out/
+              echo '{"version":"1.0.0","commit":"${commit}"}' > $out/version.json
+            '';
         };
       }
     );

--- a/index.html
+++ b/index.html
@@ -133,6 +133,7 @@
           <button id="import-btn" class="data-btn">IMPORT</button>
         </div>
       </div>
+      <div class="version-info" id="version-info"></div>
     </div>
   </div>
 

--- a/style.css
+++ b/style.css
@@ -1095,6 +1095,19 @@ footer {
 }
 
 /* =============================================
+   VERSION INFO
+   ============================================= */
+.version-info {
+  font-size: 0.7rem;
+  color: var(--text-secondary);
+  text-align: center;
+  border-top: 1px solid var(--border);
+  padding-top: 1rem;
+  margin-top: 1.25rem;
+  opacity: 0.6;
+}
+
+/* =============================================
    UTILITY CLASSES
    ============================================= */
 .hidden {


### PR DESCRIPTION
## Summary
- Generates `version.json` at Nix build time with the package version and git commit (via `self.shortRev`), falling back to `"dev"` for dirty trees
- Fetches `version.json` in `app.js` and displays `v1.0.0 · abc1234` at the bottom of the settings modal
- Gracefully handles missing `version.json` in local dev (no error, no display)
- Adds subtle `.version-info` styling: small muted text with a top border separator

## Test plan
- [x] All 106 existing e2e tests pass
- [ ] Open settings modal in a Nix build — verify version and commit hash appear
- [ ] Open settings modal in local dev (`serve .`) — verify no errors and no version text shown
- [ ] Verify version text is subtle and doesn't interfere with settings layout

Run: 20260408-1400-fe8f
Fixes #58