### PR TITLE
docs: refresh README — fly.io URL, drop multi-theme blurb

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A static, mobile-first PWA to track and execute on a fitness goal.
 
-**Live App:** https://patflynn.github.io/flux/
+**Live App:** https://flux.gunk.dev
 
 ## Features
 
@@ -16,8 +16,8 @@ A static, mobile-first PWA to track and execute on a fitness goal.
 ## Stack
 
 - Vanilla HTML/JS/CSS
-- No build step required
-- Designed for static hosting (NixOS, GitHub Pages)
+- No build step required for local development
+- Production deploys to fly.io via the gunk-dev preview/prod pipeline; PRs get preview deployments at `https://flux-preview-<PR>.fly.dev/` via the Deploy Flux Preview workflow
 
 ## Development
 
@@ -41,7 +41,7 @@ npx playwright test
 
 ```
 ├── index.html      # App shell
-├── style.css       # Dark theme styles
+├── style.css       # Theme styles (light + dark)
 ├── app.js          # Core logic
 ├── data/
 │   └── program.json   # Workout program data

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ npx playwright test
 
 ```
 ├── index.html      # App shell
-├── style.css       # Theme styles (light + dark)
+├── style.css       # Theme styles
 ├── app.js          # Core logic
 ├── data/
 │   └── program.json   # Workout program data


### PR DESCRIPTION
## Summary

Refresh README to reflect the current state of Flux:

- **Live App URL** → `https://flux.gunk.dev` (production now hosted on fly.io with custom domain).
- **Aesthetic** → drop `Dark mode cyberpunk/terminal aesthetic`; replace with `Light and dark modes with a clean, modern UI` (PR #61 dropped the multi-theme picker in favor of a single coherent design with oklch colors).
- **Stack** → drop `Designed for static hosting (NixOS, GitHub Pages)`. Production now deploys to fly.io via the gunk-dev preview/prod pipeline. Local dev still builds-free. Added a note that PRs get preview deployments at `https://flux-preview-<PR>.fly.dev/` via the Deploy Flux Preview workflow.
- Fixed a stale `Dark theme styles` comment in the Project Structure block.

## Test plan

- [x] Read README end-to-end after editing
- [x] Verified file paths in Project Structure still exist

Run: 20260427-0627-dce1