### PR TITLE
workouts: split program import from backup import

### DIFF
--- a/src/tabs/Workouts/index.tsx
+++ b/src/tabs/Workouts/index.tsx
@@ -18,9 +18,11 @@ import {
 } from './state';
 import {
   applyImportFromFile,
+  applyProgramImportFromFile,
   downloadExport,
   exportPayload,
   formatImportMessage,
+  formatProgramImportMessage,
 } from './logic/exportImport';
 import type { LogEntry, LogMap, Phase, Program, WorkoutState } from './types';
 import { ExerciseCard } from './components/ExerciseCard';
@@ -57,8 +59,10 @@ export function Workouts() {
     })();
   }, []);
 
-  function triggerImport() {
-    document.querySelector<HTMLInputElement>('[data-testid="import-input"]')?.click();
+  function triggerProgramImport() {
+    document
+      .querySelector<HTMLInputElement>('[data-testid="import-program-input"]')
+      ?.click();
   }
 
   const phase = getCurrentPhase(program, state);
@@ -179,6 +183,23 @@ export function Workouts() {
     }
   }
 
+  async function handleProgramImport(e: Event) {
+    const input = e.target as HTMLInputElement;
+    const file = input.files?.[0];
+    input.value = '';
+    if (!file) return;
+    try {
+      const result = await applyProgramImportFromFile(file);
+      const p = await loadProgram();
+      setProgram(p);
+      setImportMessage(formatProgramImportMessage(result));
+    } catch (err) {
+      setImportMessage(
+        'Import failed: ' + (err instanceof Error ? err.message : 'unknown error'),
+      );
+    }
+  }
+
   async function handleReset() {
     if (!confirm('Reset all progress? This clears day count, exercise log, and loaded program.')) return;
     await clearAll();
@@ -231,7 +252,7 @@ export function Workouts() {
             <button
               type="button"
               class="rounded border border-flux-accent bg-flux-accent/15 px-3 py-1.5 text-xs font-semibold uppercase tracking-wider text-flux-accent"
-              onClick={triggerImport}
+              onClick={triggerProgramImport}
               data-testid="import-program-btn"
             >
               Import program file
@@ -246,6 +267,13 @@ export function Workouts() {
               Generate with AI (coming soon)
             </button>
           </div>
+          <input
+            type="file"
+            accept="application/json,.json"
+            class="hidden"
+            onChange={handleProgramImport}
+            data-testid="import-program-input"
+          />
         </div>
       ) : workout ? (
         <>
@@ -337,8 +365,11 @@ export function Workouts() {
         >
           Export
         </button>
-        <label class="cursor-pointer rounded border border-flux-border bg-flux-soft px-3 py-1.5 text-xs font-medium uppercase tracking-wider text-flux-text-secondary hover:text-flux-text-primary">
-          Import
+        <label
+          class="cursor-pointer rounded border border-flux-border bg-flux-soft px-3 py-1.5 text-xs font-medium uppercase tracking-wider text-flux-text-secondary hover:text-flux-text-primary"
+          data-testid="import-backup-label"
+        >
+          Import Backup
           <input
             type="file"
             accept="application/json,.json"

--- a/src/tabs/Workouts/logic/exportImport.ts
+++ b/src/tabs/Workouts/logic/exportImport.ts
@@ -72,7 +72,16 @@ export function formatImportMessage(result: ImportResult): string {
   const head =
     `Imported ${result.imported} of ${result.total} ${noun}` +
     (result.skipped ? ` (${result.skipped} skipped)` : '');
-  if (!result.programApplied) return head;
+  if (!result.programApplied) {
+    // Backup imported but no program inside. Old-app exports don't carry a
+    // program — point the user at the per-tab importer.
+    if (result.imported > 0) {
+      return (
+        `${head}. You still need to load a program — use "Import Program File" on the Workouts tab.`
+      );
+    }
+    return head;
+  }
   const m = result.exerciseMapping;
   if (!m) return `${head}. Program loaded.`;
   if (m.unmapped === 0) {
@@ -80,6 +89,21 @@ export function formatImportMessage(result: ImportResult): string {
   }
   return (
     `${head}. Imported. ${m.mapped} of ${m.total} exercises map to the Flux catalog.` +
+    " Unmapped will still log correctly but won't show demos."
+  );
+}
+
+export interface ProgramImportResult {
+  exerciseMapping: { mapped: number; unmapped: number; total: number };
+}
+
+export function formatProgramImportMessage(result: ProgramImportResult): string {
+  const m = result.exerciseMapping;
+  if (m.unmapped === 0) {
+    return `Program loaded; ${m.mapped} of ${m.total} exercises map to the Flux catalog.`;
+  }
+  return (
+    `Program loaded. ${m.mapped} of ${m.total} exercises map to the Flux catalog.` +
     " Unmapped will still log correctly but won't show demos."
   );
 }
@@ -329,6 +353,40 @@ function isObject(v: unknown): v is Record<string, unknown> {
   return typeof v === 'object' && v !== null && !Array.isArray(v);
 }
 
+// Apply just a program to flux-db. Accepts either a bare program object
+// (`{meta, phases}`) or a backup envelope where it pulls the `program`
+// field out. Never touches the log or workout state stores. Throws on
+// shapes we can't make sense of — the empty-state CTA surfaces these
+// errors inline.
+export async function applyProgramImport(raw: unknown): Promise<ProgramImportResult> {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    throw new Error('Invalid program file: not an object');
+  }
+  const data = raw as Record<string, unknown>;
+
+  // Envelope sniffing: a backup envelope has log/state at the top level.
+  // If we see those without a program, the caller picked the wrong file
+  // for this button — point them at the backup importer.
+  const looksLikeEnvelope = 'log' in data || 'state' in data;
+  let candidate: unknown;
+  if ('program' in data) {
+    candidate = data.program;
+  } else if (looksLikeEnvelope) {
+    throw new Error(
+      'No program in this file. To restore a backup with log + state, use the Import Backup button in the toolbar.',
+    );
+  } else {
+    candidate = data;
+  }
+
+  const migrated = migrateProgram(candidate);
+  if (!migrated) {
+    throw new Error('Invalid program file: missing meta or phases');
+  }
+  await saveProgram(migrated.program);
+  return { exerciseMapping: migrated.stats };
+}
+
 // Convenience for tests: read a File and apply.
 export async function applyImportFromFile(
   file: File,
@@ -337,6 +395,14 @@ export async function applyImportFromFile(
   const text = await file.text();
   const parsed: unknown = JSON.parse(text);
   return applyImport(parsed, opts);
+}
+
+export async function applyProgramImportFromFile(
+  file: File,
+): Promise<ProgramImportResult> {
+  const text = await file.text();
+  const parsed: unknown = JSON.parse(text);
+  return applyProgramImport(parsed);
 }
 
 export type { LogMap, Program };

--- a/tests/fixtures/backup-no-program.json
+++ b/tests/fixtures/backup-no-program.json
@@ -1,0 +1,31 @@
+{
+  "log": {
+    "1_0": {
+      "exercise": "Warmup: Band Pull-Aparts",
+      "completed": true,
+      "day": 1,
+      "timestamp": 1738000000000,
+      "difficulty": "good"
+    },
+    "1_3": {
+      "exercise": "KB Gorilla Rows",
+      "weight": 25,
+      "difficulty": "good",
+      "completed": true,
+      "day": 1,
+      "timestamp": 1738000100000
+    },
+    "8_3": {
+      "exercise": "KB Gorilla Rows",
+      "weight": 30,
+      "difficulty": "good",
+      "completed": true,
+      "day": 8,
+      "timestamp": 1738604800000
+    }
+  },
+  "state": {
+    "globalDay": 8,
+    "currentPhase": "p1"
+  }
+}

--- a/tests/fixtures/program-bare.json
+++ b/tests/fixtures/program-bare.json
@@ -1,0 +1,51 @@
+{
+  "meta": {
+    "startDate": "2026-01-01",
+    "version": "bare-fixture-1",
+    "principles": [
+      "injury_prevention",
+      "mobility_every_phase",
+      "form_over_load",
+      "longevity_focus"
+    ],
+    "constraints": {
+      "mobility_required": true,
+      "min_mobility_days_per_week": 1
+    }
+  },
+  "phases": [
+    {
+      "id": "p1",
+      "name": "Phase 1: Bare",
+      "duration_weeks": 4,
+      "schedule_pattern": ["A", "Mobility", "B", "Rest", "A", "Mobility", "Rest"],
+      "workouts": {
+        "A": {
+          "name": "Workout A — Squat & Pull",
+          "focus": "lower",
+          "exercises": [
+            { "exercise_id": "warmup-band-pull-aparts", "sets": 1, "reps": "10", "rest": "30s" },
+            { "exercise_id": "goblet-squats", "sets": 3, "reps": "8-12", "rest": "90s", "starting_weight": 20, "weight_increment": 5 },
+            { "exercise_id": "kb-gorilla-rows", "sets": 3, "reps": "8-12", "rest": "90s", "starting_weight": 20, "weight_increment": 5 }
+          ]
+        },
+        "B": {
+          "name": "Workout B — Push & Carry",
+          "focus": "upper",
+          "exercises": [
+            { "exercise_id": "swedish-ladder-pushups", "sets": 3, "reps": "8-12", "rest": "60s" },
+            { "exercise_id": "trx-inverted-rows", "sets": 3, "reps": "8-12", "rest": "90s" }
+          ]
+        },
+        "Mobility": {
+          "name": "Mobility & Flow",
+          "focus": "mobility",
+          "exercises": [
+            { "exercise_id": "cat-cow-spinal-flow", "sets": 2, "reps": "10", "rest": "30s" },
+            { "exercise_id": "thread-the-needle", "sets": 2, "reps": "8 each side", "rest": "30s" }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/tests/import.spec.ts
+++ b/tests/import.spec.ts
@@ -1,0 +1,129 @@
+import { test, expect } from '@playwright/test';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const fixtures = join(__dirname, 'fixtures');
+
+const BARE_PROGRAM = join(fixtures, 'program-bare.json');
+const BACKUP_NO_PROGRAM = join(fixtures, 'backup-no-program.json');
+const LEGACY_EXPORT = join(fixtures, 'legacy-export.json');
+
+async function resetAndLoad(page: import('@playwright/test').Page) {
+  await page.goto('/');
+  await page.evaluate(async () => {
+    await new Promise<void>((resolve) => {
+      const req = indexedDB.deleteDatabase('flux-db');
+      req.onsuccess = () => resolve();
+      req.onerror = () => resolve();
+      req.onblocked = () => resolve();
+    });
+  });
+  await page.reload();
+  await page.getByTestId('import-program-btn').waitFor();
+}
+
+test('empty-state CTA accepts a bare program JSON', async ({ page }) => {
+  await resetAndLoad(page);
+
+  await page
+    .getByTestId('import-program-input')
+    .setInputFiles(BARE_PROGRAM);
+
+  await expect(page.getByTestId('workout-name')).toBeVisible();
+  await expect(page.getByTestId('phase-name')).toContainText('Phase 1: Bare');
+  await expect(page.getByTestId('import-message')).toContainText(
+    'Program loaded',
+  );
+
+  // The bare-program importer must not touch the log store.
+  const logCount = await page.evaluate(async () => {
+    return new Promise<number>((resolve) => {
+      const req = indexedDB.open('flux-db');
+      req.onsuccess = () => {
+        const db = req.result;
+        const tx = db.transaction('log', 'readonly');
+        const countReq = tx.objectStore('log').count();
+        countReq.onsuccess = () => resolve(countReq.result);
+        countReq.onerror = () => resolve(-1);
+      };
+      req.onerror = () => resolve(-1);
+    });
+  });
+  expect(logCount).toBe(0);
+});
+
+test('empty-state CTA extracts program field from a backup envelope', async ({
+  page,
+}) => {
+  await resetAndLoad(page);
+
+  await page
+    .getByTestId('import-program-input')
+    .setInputFiles(LEGACY_EXPORT);
+
+  await expect(page.getByTestId('workout-name')).toBeVisible();
+  await expect(page.getByTestId('phase-name')).toContainText(
+    'Structural Integrity',
+  );
+  // Day counter stays at the default — the program importer does not touch state.
+  await expect(page.getByTestId('day-counter')).toHaveText('1');
+
+  // No log entries either.
+  const logCount = await page.evaluate(async () => {
+    return new Promise<number>((resolve) => {
+      const req = indexedDB.open('flux-db');
+      req.onsuccess = () => {
+        const db = req.result;
+        const tx = db.transaction('log', 'readonly');
+        const countReq = tx.objectStore('log').count();
+        countReq.onsuccess = () => resolve(countReq.result);
+        countReq.onerror = () => resolve(-1);
+      };
+      req.onerror = () => resolve(-1);
+    });
+  });
+  expect(logCount).toBe(0);
+});
+
+test('empty-state CTA rejects a no-program envelope with a helpful message', async ({
+  page,
+}) => {
+  await resetAndLoad(page);
+
+  await page
+    .getByTestId('import-program-input')
+    .setInputFiles(BACKUP_NO_PROGRAM);
+
+  await expect(page.getByTestId('import-message')).toContainText(
+    'No program in this file',
+  );
+  await expect(page.getByTestId('import-message')).toContainText(
+    'Import Backup button',
+  );
+  // Empty-state must still be showing — no program was loaded.
+  await expect(page.getByTestId('no-program')).toBeVisible();
+});
+
+test('toolbar Import Backup label is visible and surfaces guidance for no-program backups', async ({
+  page,
+}) => {
+  await resetAndLoad(page);
+
+  await expect(page.getByTestId('import-backup-label')).toContainText(
+    'Import Backup',
+  );
+
+  await page.getByTestId('import-input').setInputFiles(BACKUP_NO_PROGRAM);
+
+  // imported > 0 (the fixture has log entries) and programApplied = false →
+  // guidance message points the user at the per-tab Import Program File CTA.
+  await expect(page.getByTestId('import-message')).toContainText('Imported');
+  await expect(page.getByTestId('import-message')).toContainText(
+    'still need to load a program',
+  );
+  // State was applied, so day counter reflects the fixture's globalDay.
+  await expect(page.getByTestId('day-counter')).toHaveText('8');
+  // No program loaded → empty state still visible.
+  await expect(page.getByTestId('no-program')).toBeVisible();
+});


### PR DESCRIPTION
## Summary

Fixes the Workouts tab empty-state CTA so it can actually load programs from the files users have on hand — bare program JSON and pre-PR-65 backup envelopes both work, and old-app backups no longer leave the user stuck at the empty state with no guidance.

### Three problems, one fix

1. **Empty-state button used the wrong importer.** `IMPORT PROGRAM FILE` was wired to `applyImport()`, which requires the full `{log, state, program?}` envelope. A bare `{meta, phases}` program file was rejected with `Invalid backup: missing or malformed log`.
2. **Old-app backups have no `program` field.** The vanilla-JS `exportData()` only saved `{log, state}` (program was baked into source). After a successful backup import the empty state stayed up because `flux-db.program` was still empty.
3. **No path to import just a program.** The unified backup format mashed everything together.

### What changed

- New `applyProgramImport(raw)` in `src/tabs/Workouts/logic/exportImport.ts`. Sniffs the input shape: bare `{meta, phases}` → migrate and save; envelope with `program` → extract and save; envelope without `program` → throw a helpful error pointing at the toolbar's backup importer. Never touches the log or state stores.
- Empty-state CTA gets its own hidden file input (`import-program-input`) and handler. Errors render inline in the existing `import-message` slot.
- Toolbar button relabeled `Import Backup` (handler unchanged — still `applyImport()`).
- `formatImportMessage` now adds a one-shot hint when a backup is imported with entries but no program, telling the user to use the Workouts tab's `Import Program File` button next.
- New fixtures `program-bare.json` and `backup-no-program.json` drive the new `tests/import.spec.ts` covering all four paths from the issue.

## Acceptance criteria

- [x] Empty-state "Import Program File" accepts a bare program JSON.
- [x] Same button extracts the `program` field from a backup envelope.
- [x] Toolbar button renamed "Import Backup" and continues to require the full envelope.
- [x] No-program backup → clear one-time message: "You still need to load a program — use Import Program File on the Workouts tab."
- [x] Test fixtures + 4 new tests covering bare program, envelope-with-program, envelope-without-program, and backup-with-history guidance.
- [x] `npm run typecheck` clean.
- [x] `npm run build` clean.
- [x] `npx playwright test` — 13/13 passing.

## Test plan

- [x] Bare `{meta, phases}` JSON loads via the empty-state CTA.
- [x] Backup envelope loads via the empty-state CTA (program only — log unchanged).
- [x] `{log, state}`-only file via the empty-state CTA shows the redirect-to-backup error.
- [x] `{log, state}`-only file via the toolbar Import Backup button restores history and surfaces the "still need to load a program" hint.

Run: 20260518-1400-4bf7cfc9
Fixes #67