### PR TITLE
ci: add debug APK build job for Capacitor Android wrapper

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,6 +64,48 @@ jobs:
       - name: Build production bundle
         run: nix develop --command bash -c "npm ci && npm run build"
 
+  build-android:
+    name: Build Android (debug)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '20'
+
+      - name: Setup JDK
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
+
+      - name: Install deps and sync Capacitor
+        run: |
+          npm ci
+          npm run build
+          npx cap sync android
+
+      - name: Build debug APK
+        run: |
+          cd android
+          ./gradlew assembleDebug --no-daemon
+
+      - name: Upload debug APK
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: flux-debug-apk
+          path: android/app/build/outputs/apk/debug/app-debug.apk
+          retention-days: 7
+
   catalog-validation:
     name: Catalog Validation
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Adds a new `build-android` job to `.github/workflows/test.yml` that smoke-tests the Capacitor Android wrapper on every push and PR.

The job:
1. Installs Node 20, Temurin JDK 17, and the Android SDK (via standard GitHub Actions).
2. Runs `npm ci`, `npm run build`, then `npx cap sync android`.
3. Builds a debug APK via `./gradlew assembleDebug --no-daemon`.
4. Uploads `app-debug.apk` as a workflow artifact (7-day retention).

This is a CI-only debug build — no signing, no release pipeline.

## Toolchain choice

The Node/Java/Android toolchain runs via standard GitHub Actions rather than through Nix. The dev shell doesn't currently include the Android SDK, and adding it to `flake.nix` would be heavyweight for a CI-only smoke test. Keeping this job's toolchain self-contained is cleaner.

All actions are pinned by SHA with version comments, matching the convention in the rest of `test.yml` (enforced by the `zizmor` job).

## Deferred to follow-up issues

- Signed release builds, keystore handling, AAB, Play Store
- `versionCode` auto-increment (currently hardcoded to 1 in `android/app/build.gradle`)
- Adding the Android SDK to `flake.nix`
- Caching gradle deps (can be added later if CI is slow)

## Test plan

- [ ] CI's existing `nix-lint` and `zizmor` jobs pass against this PR (verified locally before pushing: nixfmt clean, zizmor reports no findings).
- [ ] The new `build-android` job runs on this PR and produces a `flux-debug-apk` artifact.

Run: 20260518-1830-443e15f7