### PR TITLE
flake: add android dev shell with JDK 17 + Android SDK 34

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,14 +32,21 @@ nix develop .#test --command npx playwright test
 
 ## Android
 
+The `android` dev shell provides JDK 17, gradle, and the Android SDK
+(platform 34, build-tools 34.0.0). It pulls multi-GB unfree SDK components,
+so it is intentionally separate from the default shell:
+
 ```bash
-nix develop --command npm run build
-npx cap sync android
-cd android && ./gradlew assembleDebug
+nix develop .#android --command npm ci
+nix develop .#android --command bash -c "npm run build && npx cap sync android"
+nix develop .#android --command bash -c "cd android && ./gradlew assembleDebug"
 ```
 
-The Android build requires a host-installed Android SDK + JDK; it is not run
-in CI yet.
+The debug APK lands at `android/app/build/outputs/apk/debug/app-debug.apk`.
+
+CI builds the APK via `setup-java` + `setup-android` in
+`.github/workflows/test.yml` rather than this nix shell — the toolchains are
+decoupled intentionally.
 
 ## Project layout
 

--- a/flake.nix
+++ b/flake.nix
@@ -54,6 +54,49 @@
           '';
         };
 
+        # Separate shell for Android builds. Scoped here (not on the default
+        # shell) because androidenv pulls multi-GB unfree SDK components.
+        devShells.android =
+          let
+            androidPkgs = import nixpkgs {
+              inherit system;
+              config = {
+                allowUnfree = true;
+                android_sdk.accept_license = true;
+              };
+            };
+            androidComposition = androidPkgs.androidenv.composeAndroidPackages {
+              platformVersions = [ "34" ];
+              buildToolsVersions = [ "34.0.0" ];
+              includeNDK = false;
+            };
+            androidSdk = androidComposition.androidsdk;
+          in
+          androidPkgs.mkShell {
+            buildInputs = with androidPkgs; [
+              nodejs_20
+              jdk17
+              gradle
+              androidSdk
+            ];
+
+            ANDROID_HOME = "${androidSdk}/libexec/android-sdk";
+            ANDROID_SDK_ROOT = "${androidSdk}/libexec/android-sdk";
+            # AGP 8.x looks up aapt2; point it at the nix-provided one so gradle
+            # doesn't try to download its own copy.
+            GRADLE_OPTS = "-Dorg.gradle.project.android.aapt2FromMavenOverride=${androidSdk}/libexec/android-sdk/build-tools/34.0.0/aapt2";
+
+            shellHook = ''
+              echo "Flux android dev shell"
+              echo "  ANDROID_HOME=$ANDROID_HOME"
+              echo ""
+              echo "Commands:"
+              echo "  npm ci && npm run build && npx cap sync android   - sync web bundle into android/"
+              echo "  (cd android && ./gradlew assembleDebug)            - build debug APK"
+              echo "  (cd android && ./gradlew tasks)                    - list gradle tasks"
+            '';
+          };
+
         packages.default =
           let
             commit = self.shortRev or self.dirtyShortRev or "dev";


### PR DESCRIPTION
## Summary

Adds a new `devShells.android` to `flake.nix` providing the toolchain needed to build the Capacitor debug APK locally without relying on a host-installed SDK:

- JDK 17 (matches CI)
- gradle (for raw gradle exploration; `./gradlew` still downloads its own pinned 8.2.1)
- Android SDK platform 34 + build-tools 34.0.0 via `androidenv.composeAndroidPackages`
- `ANDROID_HOME` / `ANDROID_SDK_ROOT` exported, plus an `aapt2FromMavenOverride` so AGP 8.x uses the nix-provided binary instead of fetching its own

The shell is scoped separately (rather than extended onto `devShells.default`) because `androidenv` pulls multi-GB unfree SDK components — most flux dev is web-only and shouldn't pay that cost. The same pattern is used for `devShells.test` (Playwright).

End-to-end verification: `nix develop .#android` followed by `npm ci && npm run build && npx cap sync android && (cd android && ./gradlew assembleDebug --no-daemon)` produces `android/app/build/outputs/apk/debug/app-debug.apk` (3.8 MB).

## Local build

```bash
nix develop .#android --command npm ci
nix develop .#android --command bash -c "npm run build && npx cap sync android"
nix develop .#android --command bash -c "cd android && ./gradlew assembleDebug"
```

## CI

CI continues to use `setup-java` + `setup-android` in `.github/workflows/test.yml` — left alone intentionally. The local-dev toolchain and CI toolchain are decoupled; moving CI to a nix-provided Android SDK would need a separate decision about cache strategy.

## Test plan

- [x] `nix run nixpkgs#nixfmt -- --check .` passes
- [x] `nix flake check --all-systems` passes (android shell evaluates across all four supported systems)
- [x] `nix develop .#android` end-to-end produces `app-debug.apk`
- [x] Existing default / test shells unchanged

Run: 20260518-2024-f17be9eb