### PR TITLE
settings: move Export / Import Backup from Workouts toolbar into Settings

### DIFF
--- a/src/tabs/Settings.tsx
+++ b/src/tabs/Settings.tsx
@@ -1,5 +1,11 @@
 import { useEffect, useState } from 'preact/hooks';
 import { useLLM } from '../llm';
+import {
+  applyImportFromFile,
+  downloadExport,
+  exportPayload,
+  formatImportMessage,
+} from './Workouts/logic/exportImport';
 
 const MODE_STORAGE_KEY = 'flux_mode';
 type Mode = 'dark' | 'light';
@@ -27,10 +33,31 @@ function applyMode(mode: Mode): void {
 export function Settings() {
   const { available } = useLLM();
   const [mode, setMode] = useState<Mode>(detectInitialMode);
+  const [importMessage, setImportMessage] = useState<string | null>(null);
 
   useEffect(() => {
     applyMode(mode);
   }, [mode]);
+
+  async function handleExport() {
+    const payload = await exportPayload();
+    downloadExport(payload);
+  }
+
+  async function handleImport(e: Event) {
+    const input = e.target as HTMLInputElement;
+    const file = input.files?.[0];
+    input.value = '';
+    if (!file) return;
+    try {
+      const result = await applyImportFromFile(file, { applyState: true });
+      setImportMessage(formatImportMessage(result));
+    } catch (err) {
+      setImportMessage(
+        'Import failed: ' + (err instanceof Error ? err.message : 'unknown error'),
+      );
+    }
+  }
 
   return (
     <section class="mx-auto max-w-md space-y-6">
@@ -67,6 +94,43 @@ export function Settings() {
         <p class="mt-2 text-sm text-flux-text-secondary">
           {available ? 'Configured' : 'Not configured'}
         </p>
+      </div>
+
+      <div class="rounded-lg border border-flux-border bg-flux-card p-4">
+        <h2 class="text-xs font-semibold uppercase tracking-[0.16em] text-flux-text-tertiary">
+          Data
+        </h2>
+        <div class="mt-3 flex flex-wrap items-center gap-2">
+          <button
+            type="button"
+            class="rounded border border-flux-border bg-flux-soft px-3 py-1.5 text-xs font-medium uppercase tracking-wider text-flux-text-secondary hover:text-flux-text-primary"
+            onClick={handleExport}
+            data-testid="export-btn"
+          >
+            Export
+          </button>
+          <label
+            class="cursor-pointer rounded border border-flux-border bg-flux-soft px-3 py-1.5 text-xs font-medium uppercase tracking-wider text-flux-text-secondary hover:text-flux-text-primary"
+            data-testid="import-backup-label"
+          >
+            Import Backup
+            <input
+              type="file"
+              accept="application/json,.json"
+              class="hidden"
+              onChange={handleImport}
+              data-testid="import-input"
+            />
+          </label>
+        </div>
+        {importMessage && (
+          <p
+            class="mt-3 rounded border border-flux-border bg-flux-soft px-3 py-2 text-xs text-flux-text-secondary"
+            data-testid="import-message"
+          >
+            {importMessage}
+          </p>
+        )}
       </div>
     </section>
   );

--- a/src/tabs/Workouts/index.tsx
+++ b/src/tabs/Workouts/index.tsx
@@ -17,11 +17,7 @@ import {
   saveState,
 } from './state';
 import {
-  applyImportFromFile,
   applyProgramImportFromFile,
-  downloadExport,
-  exportPayload,
-  formatImportMessage,
   formatProgramImportMessage,
 } from './logic/exportImport';
 import type { LogEntry, LogMap, Phase, Program, WorkoutState } from './types';
@@ -157,30 +153,6 @@ export function Workouts() {
     const ns: WorkoutState = { globalDay: day, currentPhase: nextPhaseId };
     setState(ns);
     saveState(ns).catch(() => {});
-  }
-
-  async function handleExport() {
-    const payload = await exportPayload();
-    downloadExport(payload);
-  }
-
-  async function handleImport(e: Event) {
-    const input = e.target as HTMLInputElement;
-    const file = input.files?.[0];
-    input.value = '';
-    if (!file) return;
-    try {
-      const result = await applyImportFromFile(file, { applyState: true });
-      const [s, l, p] = await Promise.all([loadState(), loadLog(), loadProgram()]);
-      setState(s);
-      setLog(l);
-      setProgram(p);
-      setImportMessage(formatImportMessage(result));
-    } catch (err) {
-      setImportMessage(
-        'Import failed: ' + (err instanceof Error ? err.message : 'unknown error'),
-      );
-    }
   }
 
   async function handleProgramImport(e: Event) {
@@ -357,27 +329,6 @@ export function Workouts() {
           Complete & Advance →
         </button>
         <span class="flex-1" />
-        <button
-          type="button"
-          class="rounded border border-flux-border bg-flux-soft px-3 py-1.5 text-xs font-medium uppercase tracking-wider text-flux-text-secondary hover:text-flux-text-primary"
-          onClick={handleExport}
-          data-testid="export-btn"
-        >
-          Export
-        </button>
-        <label
-          class="cursor-pointer rounded border border-flux-border bg-flux-soft px-3 py-1.5 text-xs font-medium uppercase tracking-wider text-flux-text-secondary hover:text-flux-text-primary"
-          data-testid="import-backup-label"
-        >
-          Import Backup
-          <input
-            type="file"
-            accept="application/json,.json"
-            class="hidden"
-            onChange={handleImport}
-            data-testid="import-input"
-          />
-        </label>
         <button
           type="button"
           class="rounded border border-flux-border bg-flux-soft px-3 py-1.5 text-xs font-medium uppercase tracking-wider text-flux-danger hover:opacity-80"

--- a/tests/import-export.spec.ts
+++ b/tests/import-export.spec.ts
@@ -18,10 +18,15 @@ test('imports a legacy export file and exposes history', async ({ page }) => {
   });
   await page.reload();
 
-  // The fixture's state.globalDay is 8. After import we should land there.
+  // Backup import lives on the Settings tab now.
+  await page.locator('[data-tab="settings"]').click();
   await page.getByTestId('import-input').setInputFiles(FIXTURE_PATH);
-
   await expect(page.getByTestId('import-message')).toContainText('Imported');
+
+  // Switch back to Workouts — re-mount reloads state/log/program from IDB.
+  await page.locator('[data-tab="workouts"]').click();
+
+  // The fixture's state.globalDay is 8. After import we should land there.
   await expect(page.getByTestId('day-counter')).toHaveText('8');
 
   // Day 8 in phase 1 maps to schedule index (8 - 1) % 7 = 0 → workout A.
@@ -42,7 +47,8 @@ test('exports a payload matching the legacy schema', async ({ page }) => {
   });
   await page.reload();
 
-  // Seed via the import flow first.
+  // Seed via the import flow first — both buttons live in Settings.
+  await page.locator('[data-tab="settings"]').click();
   await page.getByTestId('import-input').setInputFiles(FIXTURE_PATH);
   await expect(page.getByTestId('import-message')).toContainText('Imported');
 

--- a/tests/import.spec.ts
+++ b/tests/import.spec.ts
@@ -105,10 +105,13 @@ test('empty-state CTA rejects a no-program envelope with a helpful message', asy
   await expect(page.getByTestId('no-program')).toBeVisible();
 });
 
-test('toolbar Import Backup label is visible and surfaces guidance for no-program backups', async ({
+test('Settings Import Backup label is visible and surfaces guidance for no-program backups', async ({
   page,
 }) => {
   await resetAndLoad(page);
+
+  // Backup import lives in the Settings tab now.
+  await page.locator('[data-tab="settings"]').click();
 
   await expect(page.getByTestId('import-backup-label')).toContainText(
     'Import Backup',
@@ -122,6 +125,9 @@ test('toolbar Import Backup label is visible and surfaces guidance for no-progra
   await expect(page.getByTestId('import-message')).toContainText(
     'still need to load a program',
   );
+
+  // Switch back to Workouts — re-mount picks up the imported state from IDB.
+  await page.locator('[data-tab="workouts"]').click();
   // State was applied, so day counter reflects the fixture's globalDay.
   await expect(page.getByTestId('day-counter')).toHaveText('8');
   // No program loaded → empty state still visible.

--- a/tests/workouts.spec.ts
+++ b/tests/workouts.spec.ts
@@ -21,7 +21,12 @@ async function resetAndSeedProgram(page: import('@playwright/test').Page) {
   });
   await page.reload();
   await page.getByTestId('import-program-btn').waitFor();
+  // Backup import lives in the Settings tab now — seed via Settings, then
+  // switch back to Workouts so the tab re-mounts and reloads from IDB.
+  await page.locator('[data-tab="settings"]').click();
   await page.getByTestId('import-input').setInputFiles(PROGRAM_FIXTURE);
+  await expect(page.getByTestId('import-message')).toContainText('Imported');
+  await page.locator('[data-tab="workouts"]').click();
   await expect(page.getByTestId('workout-name')).toBeVisible();
 }
 


### PR DESCRIPTION
## Summary

Move the **Export** and **Import Backup** controls from the bottom of the Workouts tab into a new **Data** section in the Settings tab. They're configuration/data controls and group naturally with the existing Appearance and LLM provider sections.

- New `Data` card in Settings holds Export + Import Backup (with the import message display).
- Workouts toolbar now contains only day-navigation (Back / Advance) and Reset.
- Test IDs (`export-btn`, `import-backup-label`, `import-input`, `import-message`) are preserved so the existing assertions still work — tests just navigate to Settings first.
- The empty-state program-import flow (`import-program-btn` / `import-program-input`) is unchanged; it's program-specific and stays in Workouts.

## Architecture note

`App.tsx` conditionally renders each tab (`{active === 'workouts' && <Workouts />}`), so when the user switches back to Workouts after importing a backup in Settings, Workouts re-mounts and its initial effect re-runs `loadState() + loadLog() + loadProgram()` against IDB — picking up the freshly imported data. Settings only needs to write through the existing `exportImport` helpers; no cross-tab event system or state lift required.

## Open question for reviewer

**Reset is still in the Workouts toolbar — should it also move to Settings under Data?** It's destructive and groups naturally with backup data. Left for a separate decision so this PR stays focused on the Export / Import move.

## Manual sanity check

- Workouts bottom toolbar now shows only `← Back`, `Complete & Advance →`, and `Reset`.
- Settings shows three cards: Appearance, LLM provider, Data. The Data card contains Export and Import Backup, with the import status message appearing below them after an import.

## Test plan
- [x] `nix develop --command npm run typecheck` — passes
- [x] `nix develop --command bash -c "npm ci && npm run build"` — passes
- [x] `nix develop .#test --command npx playwright test --project=chromium` — 13/13 pass, including the relocated import/export assertions
- [x] `klaus _pre-review` — no issues

Run: 20260518-2057-bf8abd79