### PR TITLE
settings: move Reset to Data card; dismissible import messages

### DIFF
--- a/src/tabs/Settings.tsx
+++ b/src/tabs/Settings.tsx
@@ -6,6 +6,7 @@ import {
   exportPayload,
   formatImportMessage,
 } from './Workouts/logic/exportImport';
+import { clearAll } from './Workouts/state';
 
 const MODE_STORAGE_KEY = 'flux_mode';
 type Mode = 'dark' | 'light';
@@ -57,6 +58,12 @@ export function Settings() {
         'Import failed: ' + (err instanceof Error ? err.message : 'unknown error'),
       );
     }
+  }
+
+  async function handleReset() {
+    if (!confirm('Reset all progress? This clears day count, exercise log, and loaded program.')) return;
+    await clearAll();
+    setImportMessage('Reset complete.');
   }
 
   return (
@@ -124,13 +131,36 @@ export function Settings() {
           </label>
         </div>
         {importMessage && (
-          <p
-            class="mt-3 rounded border border-flux-border bg-flux-soft px-3 py-2 text-xs text-flux-text-secondary"
-            data-testid="import-message"
+          <div
+            class="mt-3 flex items-start justify-between gap-2 rounded border border-flux-border bg-flux-soft px-3 py-2 text-xs text-flux-text-secondary"
+            data-testid="backup-import-message"
           >
-            {importMessage}
-          </p>
+            <span class="flex-1">{importMessage}</span>
+            <button
+              type="button"
+              onClick={() => setImportMessage(null)}
+              class="shrink-0 text-flux-text-tertiary hover:text-flux-text-primary"
+              aria-label="Dismiss"
+              data-testid="backup-import-message-dismiss"
+            >
+              ×
+            </button>
+          </div>
         )}
+
+        <div class="mt-4 border-t border-flux-border pt-4">
+          <p class="text-[11px] font-semibold uppercase tracking-wider text-flux-danger">
+            Danger zone
+          </p>
+          <button
+            type="button"
+            class="mt-2 rounded border border-flux-border bg-flux-soft px-3 py-1.5 text-xs font-medium uppercase tracking-wider text-flux-danger hover:opacity-80"
+            onClick={handleReset}
+            data-testid="reset-btn"
+          >
+            Reset all progress
+          </button>
+        </div>
       </div>
     </section>
   );

--- a/src/tabs/Settings.tsx
+++ b/src/tabs/Settings.tsx
@@ -62,8 +62,14 @@ export function Settings() {
 
   async function handleReset() {
     if (!confirm('Reset all progress? This clears day count, exercise log, and loaded program.')) return;
-    await clearAll();
-    setImportMessage('Reset complete.');
+    try {
+      await clearAll();
+      setImportMessage('Reset complete.');
+    } catch (err) {
+      setImportMessage(
+        'Reset failed: ' + (err instanceof Error ? err.message : 'unknown error'),
+      );
+    }
   }
 
   return (

--- a/src/tabs/Workouts/index.tsx
+++ b/src/tabs/Workouts/index.tsx
@@ -8,7 +8,6 @@ import {
 import { resolveExercise } from './logic/resolveExercise';
 import {
   DEFAULT_STATE,
-  clearAll,
   deleteLogEntry,
   loadLog,
   loadProgram,
@@ -172,14 +171,6 @@ export function Workouts() {
     }
   }
 
-  async function handleReset() {
-    if (!confirm('Reset all progress? This clears day count, exercise log, and loaded program.')) return;
-    await clearAll();
-    setState({ ...DEFAULT_STATE });
-    setLog({});
-    setProgram(null);
-  }
-
   if (!loaded) {
     return (
       <section class="flex h-full items-center justify-center">
@@ -328,24 +319,24 @@ export function Workouts() {
         >
           Complete & Advance →
         </button>
-        <span class="flex-1" />
-        <button
-          type="button"
-          class="rounded border border-flux-border bg-flux-soft px-3 py-1.5 text-xs font-medium uppercase tracking-wider text-flux-danger hover:opacity-80"
-          onClick={handleReset}
-          data-testid="reset-btn"
-        >
-          Reset
-        </button>
       </div>
 
       {importMessage && (
-        <p
-          class="rounded border border-flux-border bg-flux-card px-3 py-2 text-xs text-flux-text-secondary"
-          data-testid="import-message"
+        <div
+          class="flex items-start justify-between gap-2 rounded border border-flux-border bg-flux-card px-3 py-2 text-xs text-flux-text-secondary"
+          data-testid="program-import-message"
         >
-          {importMessage}
-        </p>
+          <span class="flex-1">{importMessage}</span>
+          <button
+            type="button"
+            onClick={() => setImportMessage(null)}
+            class="shrink-0 text-flux-text-tertiary hover:text-flux-text-primary"
+            aria-label="Dismiss"
+            data-testid="program-import-message-dismiss"
+          >
+            ×
+          </button>
+        </div>
       )}
 
       {video && (

--- a/tests/import-export.spec.ts
+++ b/tests/import-export.spec.ts
@@ -21,7 +21,7 @@ test('imports a legacy export file and exposes history', async ({ page }) => {
   // Backup import lives on the Settings tab now.
   await page.locator('[data-tab="settings"]').click();
   await page.getByTestId('import-input').setInputFiles(FIXTURE_PATH);
-  await expect(page.getByTestId('import-message')).toContainText('Imported');
+  await expect(page.getByTestId('backup-import-message')).toContainText('Imported');
 
   // Switch back to Workouts — re-mount reloads state/log/program from IDB.
   await page.locator('[data-tab="workouts"]').click();
@@ -50,7 +50,7 @@ test('exports a payload matching the legacy schema', async ({ page }) => {
   // Seed via the import flow first — both buttons live in Settings.
   await page.locator('[data-tab="settings"]').click();
   await page.getByTestId('import-input').setInputFiles(FIXTURE_PATH);
-  await expect(page.getByTestId('import-message')).toContainText('Imported');
+  await expect(page.getByTestId('backup-import-message')).toContainText('Imported');
 
   const downloadPromise = page.waitForEvent('download');
   await page.getByTestId('export-btn').click();

--- a/tests/import.spec.ts
+++ b/tests/import.spec.ts
@@ -32,7 +32,7 @@ test('empty-state CTA accepts a bare program JSON', async ({ page }) => {
 
   await expect(page.getByTestId('workout-name')).toBeVisible();
   await expect(page.getByTestId('phase-name')).toContainText('Phase 1: Bare');
-  await expect(page.getByTestId('import-message')).toContainText(
+  await expect(page.getByTestId('program-import-message')).toContainText(
     'Program loaded',
   );
 
@@ -95,14 +95,30 @@ test('empty-state CTA rejects a no-program envelope with a helpful message', asy
     .getByTestId('import-program-input')
     .setInputFiles(BACKUP_NO_PROGRAM);
 
-  await expect(page.getByTestId('import-message')).toContainText(
+  await expect(page.getByTestId('program-import-message')).toContainText(
     'No program in this file',
   );
-  await expect(page.getByTestId('import-message')).toContainText(
+  await expect(page.getByTestId('program-import-message')).toContainText(
     'Import Backup button',
   );
   // Empty-state must still be showing — no program was loaded.
   await expect(page.getByTestId('no-program')).toBeVisible();
+});
+
+test('program-import message can be dismissed', async ({ page }) => {
+  await resetAndLoad(page);
+
+  await page
+    .getByTestId('import-program-input')
+    .setInputFiles(BARE_PROGRAM);
+
+  await expect(page.getByTestId('program-import-message')).toContainText(
+    'Program loaded',
+  );
+
+  await page.getByTestId('program-import-message-dismiss').click();
+
+  await expect(page.getByTestId('program-import-message')).toHaveCount(0);
 });
 
 test('Settings Import Backup label is visible and surfaces guidance for no-program backups', async ({
@@ -121,8 +137,8 @@ test('Settings Import Backup label is visible and surfaces guidance for no-progr
 
   // imported > 0 (the fixture has log entries) and programApplied = false →
   // guidance message points the user at the per-tab Import Program File CTA.
-  await expect(page.getByTestId('import-message')).toContainText('Imported');
-  await expect(page.getByTestId('import-message')).toContainText(
+  await expect(page.getByTestId('backup-import-message')).toContainText('Imported');
+  await expect(page.getByTestId('backup-import-message')).toContainText(
     'still need to load a program',
   );
 

--- a/tests/workouts.spec.ts
+++ b/tests/workouts.spec.ts
@@ -25,7 +25,7 @@ async function resetAndSeedProgram(page: import('@playwright/test').Page) {
   // switch back to Workouts so the tab re-mounts and reloads from IDB.
   await page.locator('[data-tab="settings"]').click();
   await page.getByTestId('import-input').setInputFiles(PROGRAM_FIXTURE);
-  await expect(page.getByTestId('import-message')).toContainText('Imported');
+  await expect(page.getByTestId('backup-import-message')).toContainText('Imported');
   await page.locator('[data-tab="workouts"]').click();
   await expect(page.getByTestId('workout-name')).toBeVisible();
 }


### PR DESCRIPTION
## Summary

Combined follow-up to PR #76 (Settings Export/Import move). Three related changes that touch the same files, bundled into one PR.

### Move Reset into Settings → Data
- Moved `handleReset` from the Workouts bottom toolbar into the Settings Data card, under a new "Danger zone" divider with `text-flux-danger` styling.
- Settings doesn't hold workout state, so `handleReset` just calls `clearAll()` and surfaces a "Reset complete." message. Switching back to Workouts re-mounts the tab and reloads from IDB (same pattern as PR #76's Import).
- The `confirm()` dialog is preserved; `data-testid="reset-btn"` is preserved.

### Dismissible import status messages
- Both import-message displays (program-import on Workouts, backup-import on Settings) now render as a flex card with a `×` dismiss button on the right. Clicking it clears the relevant `importMessage` state.
- No auto-dismiss timer — users control when errors disappear.

### Disambiguate duplicate test IDs
- Both displays previously used `data-testid="import-message"`. Renamed to flow-specific IDs:
  - Workouts: `program-import-message` (+ `program-import-message-dismiss`)
  - Settings: `backup-import-message` (+ `backup-import-message-dismiss`)
- Updated all call sites in `tests/import-export.spec.ts`, `tests/import.spec.ts`, and `tests/workouts.spec.ts` according to which flow each test exercises.

### Test coverage
- Added a Playwright test (`program-import message can be dismissed`) that imports a bare program, asserts the message renders, clicks the dismiss button, and asserts the message is gone.

### Note
After moving Reset, the Workouts bottom toolbar contains only prev-day + next-day. The flex spacer that previously pushed Reset to the right was removed since there is nothing to push.

Closes #74
Closes #75

## Test plan

- [x] `nix develop --command npm run typecheck` — no TS errors
- [x] `nix develop --command bash -c "npm ci && npm run build"` — production build succeeds
- [x] `nix develop .#test --command npx playwright test --project=chromium` — all 15 e2e tests pass (including new dismiss test)

Run: 20260518-2108-7f7bdc36