### PR TITLE
prototype: re-skin UI to match balance design language (preview)

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,8 @@
       name="viewport"
       content="width=device-width, initial-scale=1.0, user-scalable=no"
     />
-    <meta name="theme-color" content="#0a0a0a" />
+    <meta name="theme-color" content="#dce3d0" media="(prefers-color-scheme: light)" />
+    <meta name="theme-color" content="#2a302b" media="(prefers-color-scheme: dark)" />
     <title>Flux</title>
     <link rel="manifest" href="/manifest.json" />
   </head>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,7 +40,10 @@ export function App({ entry }: { entry: EntryTab }) {
 
   return (
     <div class="flex h-full flex-col bg-flux-bg text-flux-text-primary">
-      <main class="flex-1 overflow-y-auto p-4" data-active-tab={active}>
+      <main
+        class="flex-1 overflow-y-auto px-4 pb-28 pt-6 sm:px-6"
+        data-active-tab={active}
+      >
         {active === 'workouts' && <Workouts />}
         {active === 'meditate' && <Meditate />}
         {active === 'checkin' && <Checkin />}
@@ -48,31 +51,33 @@ export function App({ entry }: { entry: EntryTab }) {
       </main>
 
       <nav
-        class="grid grid-cols-4 border-t border-flux-border bg-flux-card"
+        class="pointer-events-none fixed inset-x-0 bottom-0 z-40 flex justify-center px-4 pb-4"
         role="tablist"
         aria-label="Primary"
       >
-        {TABS.map((t) => {
-          const selected = active === t.key;
-          return (
-            <button
-              key={t.key}
-              type="button"
-              role="tab"
-              aria-selected={selected}
-              data-tab={t.key}
-              onClick={() => setActive(t.key)}
-              class={
-                'py-3 text-sm font-medium transition-colors ' +
-                (selected
-                  ? 'bg-flux-soft text-flux-text-primary'
-                  : 'text-flux-text-tertiary hover:text-flux-text-secondary')
-              }
-            >
-              {t.label}
-            </button>
-          );
-        })}
+        <div class="pointer-events-auto grid w-full max-w-md grid-cols-4 gap-1 rounded-full bg-flux-card p-1.5 shadow-flux-nav">
+          {TABS.map((t) => {
+            const selected = active === t.key;
+            return (
+              <button
+                key={t.key}
+                type="button"
+                role="tab"
+                aria-selected={selected}
+                data-tab={t.key}
+                onClick={() => setActive(t.key)}
+                class={
+                  'rounded-full px-2 py-2.5 text-[10px] font-medium uppercase tracking-[0.18em] transition-all ' +
+                  (selected
+                    ? 'bg-flux-accent text-flux-card shadow-flux-soft'
+                    : 'text-flux-text-tertiary hover:text-flux-text-secondary')
+                }
+              >
+                {t.label}
+              </button>
+            );
+          })}
+        </div>
       </nav>
     </div>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -69,7 +69,7 @@ export function App({ entry }: { entry: EntryTab }) {
                 class={
                   'rounded-full px-2 py-2.5 text-[10px] font-medium uppercase tracking-[0.18em] transition-all ' +
                   (selected
-                    ? 'bg-flux-accent text-flux-card shadow-flux-soft'
+                    ? 'bg-flux-accent text-flux-accent-fg shadow-flux-soft'
                     : 'text-flux-text-tertiary hover:text-flux-text-secondary')
                 }
               >

--- a/src/index.css
+++ b/src/index.css
@@ -1,33 +1,51 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
-/* Theme tokens. Default to dark; light overrides via [data-mode="light"]. */
+/*
+ * Balance design language ported to flux.
+ *
+ * Source palette (light mode = balance verbatim):
+ *   sage   #dce3d0 — app background
+ *   cream  #f4f3ea — primary card surface
+ *   sand   #e8e6dd — secondary surface (inputs, soft chips)
+ *   forest #4a534b — primary text + dark accent button
+ *   mint   #a2b8ad — call-to-action surfaces, completed states
+ *
+ * Dark mode is derived to preserve balance's warm/earthy spirit
+ * (no grey reversion). Bg/card/soft are stepped from a deep
+ * muted-green; text uses dimmed cream; mint is shared with light.
+ */
+
 :root {
-  --flux-bg: oklch(0.16 0.005 250);
-  --flux-card: oklch(0.20 0.006 250);
-  --flux-soft: oklch(0.24 0.006 250);
-  --flux-border: oklch(0.28 0.006 250);
-  --flux-border-strong: oklch(0.34 0.006 250);
-  --flux-text-primary: oklch(0.96 0.005 80);
-  --flux-text-secondary: oklch(0.72 0.008 80);
-  --flux-text-tertiary: oklch(0.52 0.008 80);
-  --flux-accent: oklch(0.78 0.09 155);
-  --flux-accent-dim: oklch(0.66 0.09 155);
-  --flux-danger: oklch(0.58 0.18 25);
+  /* Dark mode is the legacy default; matches index.html's `class="dark"`. */
+  --flux-bg: #2a302b;
+  --flux-card: #363d37;
+  --flux-soft: #3f4740;
+  --flux-border: rgba(244, 243, 234, 0.07);
+  --flux-border-strong: rgba(244, 243, 234, 0.14);
+  --flux-text-primary: #ece9dc;
+  --flux-text-secondary: rgba(184, 196, 188, 0.92);
+  --flux-text-tertiary: rgba(162, 184, 173, 0.72);
+  --flux-accent: #a2b8ad;
+  --flux-accent-dim: #7d9489;
+  --flux-danger: #c98686;
 }
 
 [data-mode='light'] {
-  --flux-bg: oklch(0.985 0.004 80);
-  --flux-card: oklch(0.995 0.003 80);
-  --flux-soft: oklch(0.965 0.005 80);
-  --flux-border: oklch(0.92 0.005 80);
-  --flux-border-strong: oklch(0.88 0.005 80);
-  --flux-text-primary: oklch(0.18 0.01 250);
-  --flux-text-secondary: oklch(0.42 0.01 250);
-  --flux-text-tertiary: oklch(0.62 0.01 250);
-  --flux-accent: oklch(0.62 0.07 155);
-  --flux-accent-dim: oklch(0.52 0.07 155);
+  --flux-bg: #dce3d0;
+  --flux-card: #f4f3ea;
+  --flux-soft: #e8e6dd;
+  --flux-border: rgba(74, 83, 75, 0.08);
+  --flux-border-strong: rgba(74, 83, 75, 0.16);
+  --flux-text-primary: #4a534b;
+  --flux-text-secondary: #6e7972;
+  --flux-text-tertiary: #8d978f;
+  --flux-accent: #a2b8ad;
+  --flux-accent-dim: #7d9489;
+  --flux-danger: #b85c5c;
 }
 
 html,
@@ -40,7 +58,13 @@ body {
   margin: 0;
   background: var(--flux-bg);
   color: var(--flux-text-primary);
-  font-family: 'Inter Tight', 'Inter', ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+  font-family: 'Inter', ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
   -webkit-tap-highlight-color: transparent;
-  letter-spacing: -0.005em;
+}
+
+/* Focus rings — visible on dark or light, mint-tinted to match palette. */
+:where(button, [role='tab'], a, input, textarea, select):focus-visible {
+  outline: 2px solid var(--flux-accent);
+  outline-offset: 2px;
+  border-radius: inherit;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -31,6 +31,10 @@
   --flux-text-tertiary: rgba(162, 184, 173, 0.72);
   --flux-accent: #a2b8ad;
   --flux-accent-dim: #7d9489;
+  /* Foreground for content sitting on --flux-accent. Mint is identical in
+     both themes, so we use a deep forest tone here to clear WCAG AA
+     (~6.9:1) on the same background regardless of mode. */
+  --flux-accent-fg: #252b26;
   --flux-danger: #c98686;
 }
 
@@ -45,6 +49,7 @@
   --flux-text-tertiary: #8d978f;
   --flux-accent: #a2b8ad;
   --flux-accent-dim: #7d9489;
+  --flux-accent-fg: #252b26;
   --flux-danger: #b85c5c;
 }
 

--- a/src/tabs/Checkin.tsx
+++ b/src/tabs/Checkin.tsx
@@ -1,8 +1,22 @@
 export function Checkin() {
   return (
-    <section class="flex h-full flex-col items-center justify-center text-center">
-      <h1 class="text-2xl font-semibold">Check-in</h1>
-      <p class="mt-2 text-sm text-neutral-400">Coming in PR 4.</p>
+    <section class="mx-auto flex h-full max-w-md flex-col items-center justify-center text-center">
+      <div class="flex w-full flex-col items-center gap-6 rounded-[2rem] bg-flux-card px-8 py-16 shadow-flux-card">
+        <div aria-hidden="true" class="flex items-center gap-2">
+          <span class="h-2 w-2 rounded-full bg-flux-accent" />
+          <span class="h-2 w-12 rounded-full bg-flux-accent/40" />
+          <span class="h-2 w-2 rounded-full bg-flux-accent/20" />
+        </div>
+        <h1 class="text-sm font-medium uppercase tracking-[0.28em] text-flux-text-primary">
+          Check-in
+        </h1>
+        <p class="max-w-xs text-sm leading-relaxed text-flux-text-secondary">
+          A daily pulse on mood, energy, and recovery. Coming after Meditate.
+        </p>
+        <span class="text-[10px] uppercase tracking-[0.2em] text-flux-text-tertiary">
+          Coming soon
+        </span>
+      </div>
     </section>
   );
 }

--- a/src/tabs/Meditate.tsx
+++ b/src/tabs/Meditate.tsx
@@ -1,8 +1,22 @@
 export function Meditate() {
   return (
-    <section class="flex h-full flex-col items-center justify-center text-center">
-      <h1 class="text-2xl font-semibold">Meditate</h1>
-      <p class="mt-2 text-sm text-neutral-400">Coming in PR 3.</p>
+    <section class="mx-auto flex h-full max-w-md flex-col items-center justify-center text-center">
+      <div class="flex w-full flex-col items-center gap-6 rounded-[2rem] bg-flux-card px-8 py-16 shadow-flux-card">
+        <span
+          aria-hidden="true"
+          class="block h-16 w-16 rounded-full bg-flux-accent/30"
+          style={{ boxShadow: '0 0 0 8px var(--flux-soft)' }}
+        />
+        <h1 class="text-sm font-medium uppercase tracking-[0.28em] text-flux-text-primary">
+          Meditate
+        </h1>
+        <p class="max-w-xs text-sm leading-relaxed text-flux-text-secondary">
+          Stillness as practice. Guided sessions arrive in a later release.
+        </p>
+        <span class="text-[10px] uppercase tracking-[0.2em] text-flux-text-tertiary">
+          Coming soon
+        </span>
+      </div>
     </section>
   );
 }

--- a/src/tabs/Settings.tsx
+++ b/src/tabs/Settings.tsx
@@ -95,7 +95,7 @@ export function Settings() {
               class={
                 'rounded-full px-4 py-1.5 text-[11px] font-medium uppercase tracking-[0.18em] transition-all ' +
                 (mode === m
-                  ? 'bg-flux-accent text-flux-card shadow-flux-soft'
+                  ? 'bg-flux-accent text-flux-accent-fg shadow-flux-soft'
                   : 'text-flux-text-secondary hover:text-flux-text-primary')
               }
               data-mode={m}

--- a/src/tabs/Settings.tsx
+++ b/src/tabs/Settings.tsx
@@ -73,23 +73,30 @@ export function Settings() {
   }
 
   return (
-    <section class="mx-auto max-w-md space-y-6">
-      <h1 class="text-2xl font-semibold text-flux-text-primary">Settings</h1>
+    <section class="mx-auto max-w-md space-y-5">
+      <header class="flex flex-col items-center gap-1 pt-2 text-center">
+        <h1 class="text-sm font-medium uppercase tracking-[0.28em] text-flux-text-primary">
+          Settings
+        </h1>
+        <p class="text-[10px] uppercase tracking-[0.2em] text-flux-text-tertiary">
+          Preferences & data
+        </p>
+      </header>
 
-      <div class="rounded-lg border border-flux-border bg-flux-card p-4">
-        <h2 class="text-xs font-semibold uppercase tracking-[0.16em] text-flux-text-tertiary">
+      <div class="rounded-[2rem] bg-flux-card p-6 shadow-flux-card">
+        <h2 class="text-[10px] font-medium uppercase tracking-[0.2em] text-flux-text-tertiary">
           Appearance
         </h2>
-        <div class="mt-3 inline-flex overflow-hidden rounded border border-flux-border">
+        <div class="mt-4 inline-flex rounded-full bg-flux-soft p-1">
           {(['dark', 'light'] as const).map((m) => (
             <button
               key={m}
               type="button"
               class={
-                'px-3 py-1.5 text-xs font-medium uppercase tracking-wider transition-colors ' +
+                'rounded-full px-4 py-1.5 text-[11px] font-medium uppercase tracking-[0.18em] transition-all ' +
                 (mode === m
-                  ? 'bg-flux-accent/15 text-flux-accent'
-                  : 'bg-flux-soft text-flux-text-secondary hover:text-flux-text-primary')
+                  ? 'bg-flux-accent text-flux-card shadow-flux-soft'
+                  : 'text-flux-text-secondary hover:text-flux-text-primary')
               }
               data-mode={m}
               onClick={() => setMode(m)}
@@ -100,30 +107,30 @@ export function Settings() {
         </div>
       </div>
 
-      <div class="rounded-lg border border-flux-border bg-flux-card p-4">
-        <h2 class="text-xs font-semibold uppercase tracking-[0.16em] text-flux-text-tertiary">
+      <div class="rounded-[2rem] bg-flux-card p-6 shadow-flux-card">
+        <h2 class="text-[10px] font-medium uppercase tracking-[0.2em] text-flux-text-tertiary">
           LLM provider
         </h2>
-        <p class="mt-2 text-sm text-flux-text-secondary">
+        <p class="mt-3 text-sm text-flux-text-secondary">
           {available ? 'Configured' : 'Not configured'}
         </p>
       </div>
 
-      <div class="rounded-lg border border-flux-border bg-flux-card p-4">
-        <h2 class="text-xs font-semibold uppercase tracking-[0.16em] text-flux-text-tertiary">
+      <div class="rounded-[2rem] bg-flux-card p-6 shadow-flux-card">
+        <h2 class="text-[10px] font-medium uppercase tracking-[0.2em] text-flux-text-tertiary">
           Data
         </h2>
-        <div class="mt-3 flex flex-wrap items-center gap-2">
+        <div class="mt-4 flex flex-wrap items-center gap-2">
           <button
             type="button"
-            class="rounded border border-flux-border bg-flux-soft px-3 py-1.5 text-xs font-medium uppercase tracking-wider text-flux-text-secondary hover:text-flux-text-primary"
+            class="rounded-full bg-flux-soft px-4 py-2 text-[11px] font-medium uppercase tracking-[0.15em] text-flux-text-secondary transition-colors hover:text-flux-text-primary"
             onClick={handleExport}
             data-testid="export-btn"
           >
             Export
           </button>
           <label
-            class="cursor-pointer rounded border border-flux-border bg-flux-soft px-3 py-1.5 text-xs font-medium uppercase tracking-wider text-flux-text-secondary hover:text-flux-text-primary"
+            class="cursor-pointer rounded-full bg-flux-soft px-4 py-2 text-[11px] font-medium uppercase tracking-[0.15em] text-flux-text-secondary transition-colors hover:text-flux-text-primary"
             data-testid="import-backup-label"
           >
             Import Backup
@@ -138,7 +145,7 @@ export function Settings() {
         </div>
         {importMessage && (
           <div
-            class="mt-3 flex items-start justify-between gap-2 rounded border border-flux-border bg-flux-soft px-3 py-2 text-xs text-flux-text-secondary"
+            class="mt-4 flex items-start justify-between gap-2 rounded-2xl bg-flux-soft px-4 py-3 text-xs text-flux-text-secondary"
             data-testid="backup-import-message"
           >
             <span class="flex-1">{importMessage}</span>
@@ -154,13 +161,13 @@ export function Settings() {
           </div>
         )}
 
-        <div class="mt-4 border-t border-flux-border pt-4">
-          <p class="text-[11px] font-semibold uppercase tracking-wider text-flux-danger">
+        <div class="mt-5 border-t border-flux-border pt-4">
+          <p class="text-[10px] font-medium uppercase tracking-[0.2em] text-flux-danger">
             Danger zone
           </p>
           <button
             type="button"
-            class="mt-2 rounded border border-flux-border bg-flux-soft px-3 py-1.5 text-xs font-medium uppercase tracking-wider text-flux-danger hover:opacity-80"
+            class="mt-3 rounded-full bg-flux-soft px-4 py-2 text-[11px] font-medium uppercase tracking-[0.15em] text-flux-danger transition-opacity hover:opacity-80"
             onClick={handleReset}
             data-testid="reset-btn"
           >

--- a/src/tabs/Workouts/components/ExerciseCard.tsx
+++ b/src/tabs/Workouts/components/ExerciseCard.tsx
@@ -107,22 +107,22 @@ export function ExerciseCard({
   return (
     <article
       class={
-        'rounded-lg border p-4 transition-colors ' +
+        'rounded-[2rem] p-6 transition-all ' +
         (completed
-          ? 'border-flux-accent/40 bg-flux-card'
-          : 'border-flux-border bg-flux-card')
+          ? 'bg-flux-accent/15 shadow-flux-card'
+          : 'bg-flux-card shadow-flux-card')
       }
       data-exercise-index={index}
       data-completed={completed ? 'true' : 'false'}
     >
-      <header class="flex items-start justify-between gap-2">
-        <div class="flex flex-1 flex-wrap items-center gap-2">
-          <h3 class="text-base font-semibold leading-tight text-flux-text-primary">
+      <header class="flex items-start justify-between gap-3">
+        <div class="flex-1">
+          <h3 class="text-lg font-medium leading-tight text-flux-text-primary">
             {exercise.name}
           </h3>
           {exercise.unmapped && (
             <span
-              class="rounded border border-flux-border bg-flux-soft px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-flux-text-tertiary"
+              class="mt-1 inline-block rounded-full bg-flux-soft px-2.5 py-0.5 text-[10px] uppercase tracking-[0.15em] text-flux-text-tertiary"
               data-testid={`unmapped-${index}`}
               title="Imported from a legacy export. No demo or technique notes available."
             >
@@ -133,31 +133,40 @@ export function ExerciseCard({
         {exercise.demoVideoId ? (
           <button
             type="button"
-            class="shrink-0 rounded border border-flux-border px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider text-flux-text-secondary hover:text-flux-text-primary"
+            class="shrink-0 rounded-full bg-flux-soft px-3 py-1.5 text-[10px] font-medium uppercase tracking-[0.15em] text-flux-text-secondary transition-colors hover:text-flux-text-primary"
             onClick={() => onPlayVideo(exercise.demoVideoId!, exercise.demoVideoStart)}
             data-testid={`video-${index}`}
           >
             Video
           </button>
         ) : (
-          <span class="shrink-0 rounded border border-flux-border px-2 py-0.5 text-[10px] uppercase tracking-wider text-flux-text-tertiary">
+          <span class="shrink-0 rounded-full bg-flux-soft px-3 py-1.5 text-[10px] uppercase tracking-[0.15em] text-flux-text-tertiary">
             No video
           </span>
         )}
       </header>
 
-      <div class="mt-2 flex flex-wrap gap-x-3 gap-y-1 font-mono text-xs text-flux-text-secondary">
-        <span><strong class="text-flux-text-primary">{exercise.sets}</strong> sets</span>
-        <span><strong class="text-flux-text-primary">{exercise.reps}</strong> reps</span>
-        <span><strong class="text-flux-text-primary">{exercise.rest}</strong> rest</span>
-      </div>
+      <dl class="mt-4 grid grid-cols-3 gap-2 rounded-2xl bg-flux-soft px-4 py-3">
+        <div class="flex flex-col items-center">
+          <dt class="text-[9px] font-medium uppercase tracking-[0.18em] text-flux-text-tertiary">Sets</dt>
+          <dd class="mt-0.5 text-base font-medium text-flux-text-primary">{exercise.sets}</dd>
+        </div>
+        <div class="flex flex-col items-center border-x border-flux-border">
+          <dt class="text-[9px] font-medium uppercase tracking-[0.18em] text-flux-text-tertiary">Reps</dt>
+          <dd class="mt-0.5 text-base font-medium text-flux-text-primary">{exercise.reps}</dd>
+        </div>
+        <div class="flex flex-col items-center">
+          <dt class="text-[9px] font-medium uppercase tracking-[0.18em] text-flux-text-tertiary">Rest</dt>
+          <dd class="mt-0.5 text-base font-medium text-flux-text-primary">{exercise.rest}</dd>
+        </div>
+      </dl>
 
       {exercise.techniqueNote && (
-        <p class="mt-2 text-xs leading-snug text-flux-text-tertiary">{exercise.techniqueNote}</p>
+        <p class="mt-3 text-xs leading-snug text-flux-text-tertiary">{exercise.techniqueNote}</p>
       )}
 
       {(repSeconds || restSeconds) && (
-        <div class="mt-3 flex flex-wrap gap-2">
+        <div class="mt-4 flex flex-wrap gap-2">
           {repSeconds && (
             <Timer label="Exercise" seconds={repSeconds} testId={`timer-ex-${index}`} />
           )}
@@ -168,11 +177,13 @@ export function ExerciseCard({
       )}
 
       {exercise.usesWeight && (
-        <div class="mt-3 flex items-center gap-2">
-          <span class="text-xs uppercase tracking-wider text-flux-text-tertiary">Weight</span>
+        <div class="mt-4 flex items-center gap-2">
+          <span class="text-[10px] font-medium uppercase tracking-[0.18em] text-flux-text-tertiary">
+            Weight
+          </span>
           <button
             type="button"
-            class="h-7 w-7 rounded border border-flux-border text-flux-text-secondary hover:text-flux-text-primary"
+            class="flex h-8 w-8 items-center justify-center rounded-full bg-flux-soft text-base text-flux-text-secondary transition-colors hover:text-flux-text-primary"
             onClick={() => setWeight((weight ?? suggestedWeight ?? MIN_WEIGHT) - increment)}
             aria-label="Decrease weight"
           >
@@ -180,7 +191,7 @@ export function ExerciseCard({
           </button>
           <input
             type="number"
-            class="w-20 rounded border border-flux-border bg-flux-soft px-2 py-1 font-mono text-sm text-flux-text-primary"
+            class="w-20 rounded-xl bg-flux-soft px-3 py-1.5 text-center text-sm font-medium tabular-nums text-flux-text-primary outline-none placeholder:text-flux-text-tertiary"
             value={weight ?? ''}
             placeholder={placeholder}
             onInput={handleWeightInput}
@@ -188,39 +199,41 @@ export function ExerciseCard({
           />
           <button
             type="button"
-            class="h-7 w-7 rounded border border-flux-border text-flux-text-secondary hover:text-flux-text-primary"
+            class="flex h-8 w-8 items-center justify-center rounded-full bg-flux-soft text-base text-flux-text-secondary transition-colors hover:text-flux-text-primary"
             onClick={() => setWeight((weight ?? suggestedWeight ?? MIN_WEIGHT) + increment)}
             aria-label="Increase weight"
           >
             +
           </button>
-          <span class="text-xs text-flux-text-tertiary">lbs</span>
+          <span class="text-[10px] font-medium uppercase tracking-[0.18em] text-flux-text-tertiary">
+            lbs
+          </span>
           {suggestedWeight != null && (
-            <span class="ml-auto text-[10px] uppercase tracking-wider text-flux-text-tertiary">
-              suggested {suggestedWeight}
+            <span class="ml-auto text-[10px] uppercase tracking-[0.15em] text-flux-text-tertiary">
+              ~{suggestedWeight}
             </span>
           )}
         </div>
       )}
 
-      <div class="mt-3">
+      <div class="mt-5">
         <button
           type="button"
           class={
-            'w-full rounded border px-3 py-2 text-sm font-semibold uppercase tracking-wider transition-colors ' +
+            'w-full rounded-2xl px-4 py-3 text-xs font-medium uppercase tracking-[0.2em] transition-all ' +
             (completed
-              ? 'border-flux-accent bg-flux-accent/15 text-flux-accent'
-              : 'border-flux-border bg-flux-soft text-flux-text-secondary hover:text-flux-text-primary')
+              ? 'bg-flux-accent text-flux-card shadow-flux-soft'
+              : 'bg-flux-soft text-flux-text-secondary hover:text-flux-text-primary')
           }
           onClick={toggleDone}
           data-testid={`done-${index}`}
         >
-          {completed ? '✓ Done' : 'Done'}
+          {completed ? '✓ Done' : 'Mark Done'}
         </button>
 
         {completed && (
           <>
-            <div class="mt-3 grid grid-cols-4 gap-1">
+            <div class="mt-4 grid grid-cols-4 gap-1.5">
               {(['failed', 'easy', 'good', 'hard'] as const).map((d) => {
                 const selected = difficulty === d || (!difficulty && d === 'good');
                 return (
@@ -229,10 +242,10 @@ export function ExerciseCard({
                     type="button"
                     aria-pressed={selected}
                     class={
-                      'rounded border px-2 py-1.5 text-[11px] font-medium uppercase tracking-wider transition-colors ' +
+                      'rounded-full px-2 py-2 text-[10px] font-medium uppercase tracking-[0.15em] transition-colors ' +
                       (selected
-                        ? 'border-flux-accent bg-flux-accent/15 text-flux-accent'
-                        : 'border-flux-border bg-flux-soft text-flux-text-secondary hover:text-flux-text-primary')
+                        ? 'bg-flux-accent text-flux-card'
+                        : 'bg-flux-soft text-flux-text-secondary hover:text-flux-text-primary')
                     }
                     onClick={() => setDifficulty(d)}
                     data-testid={`difficulty-${index}-${d}`}
@@ -244,15 +257,15 @@ export function ExerciseCard({
             </div>
 
             {difficulty === 'failed' && (
-              <div class="mt-3 space-y-2 rounded border border-flux-border bg-flux-soft p-2">
-                <label class="block text-[11px] uppercase tracking-wider text-flux-text-tertiary">
+              <div class="mt-4 space-y-3 rounded-2xl bg-flux-soft p-4">
+                <label class="block text-[10px] font-medium uppercase tracking-[0.18em] text-flux-text-tertiary">
                   Failed on set: <span class="text-flux-text-primary">{failedSet}</span> / {maxSets}
                   <input
                     type="range"
                     min={1}
                     max={maxSets}
                     value={failedSet}
-                    class="mt-1 block w-full"
+                    class="mt-2 block w-full accent-flux-accent"
                     onChange={(e) =>
                       onLog(key, {
                         exercise: exercise.name,
@@ -263,14 +276,14 @@ export function ExerciseCard({
                     }
                   />
                 </label>
-                <label class="block text-[11px] uppercase tracking-wider text-flux-text-tertiary">
+                <label class="block text-[10px] font-medium uppercase tracking-[0.18em] text-flux-text-tertiary">
                   Failed on rep: <span class="text-flux-text-primary">{failedRep}</span> / {maxReps}
                   <input
                     type="range"
                     min={1}
                     max={maxReps}
                     value={failedRep}
-                    class="mt-1 block w-full"
+                    class="mt-2 block w-full accent-flux-accent"
                     onChange={(e) =>
                       onLog(key, {
                         exercise: exercise.name,
@@ -287,7 +300,7 @@ export function ExerciseCard({
         )}
 
         <textarea
-          class="mt-3 block w-full rounded border border-flux-border bg-flux-soft px-2 py-1.5 font-mono text-xs text-flux-text-primary placeholder:text-flux-text-tertiary"
+          class="mt-4 block w-full rounded-2xl bg-flux-soft px-4 py-3 text-xs text-flux-text-primary outline-none placeholder:text-flux-text-tertiary"
           rows={2}
           placeholder="Notes (optional)"
           value={notes}

--- a/src/tabs/Workouts/components/ExerciseCard.tsx
+++ b/src/tabs/Workouts/components/ExerciseCard.tsx
@@ -191,7 +191,7 @@ export function ExerciseCard({
           </button>
           <input
             type="number"
-            class="w-20 rounded-xl bg-flux-soft px-3 py-1.5 text-center text-sm font-medium tabular-nums text-flux-text-primary outline-none placeholder:text-flux-text-tertiary"
+            class="w-20 rounded-xl bg-flux-soft px-3 py-1.5 text-center text-sm font-medium tabular-nums text-flux-text-primary placeholder:text-flux-text-tertiary"
             value={weight ?? ''}
             placeholder={placeholder}
             onInput={handleWeightInput}
@@ -222,7 +222,7 @@ export function ExerciseCard({
           class={
             'w-full rounded-2xl px-4 py-3 text-xs font-medium uppercase tracking-[0.2em] transition-all ' +
             (completed
-              ? 'bg-flux-accent text-flux-card shadow-flux-soft'
+              ? 'bg-flux-accent text-flux-accent-fg shadow-flux-soft'
               : 'bg-flux-soft text-flux-text-secondary hover:text-flux-text-primary')
           }
           onClick={toggleDone}
@@ -244,7 +244,7 @@ export function ExerciseCard({
                     class={
                       'rounded-full px-2 py-2 text-[10px] font-medium uppercase tracking-[0.15em] transition-colors ' +
                       (selected
-                        ? 'bg-flux-accent text-flux-card'
+                        ? 'bg-flux-accent text-flux-accent-fg'
                         : 'bg-flux-soft text-flux-text-secondary hover:text-flux-text-primary')
                     }
                     onClick={() => setDifficulty(d)}
@@ -300,7 +300,7 @@ export function ExerciseCard({
         )}
 
         <textarea
-          class="mt-4 block w-full rounded-2xl bg-flux-soft px-4 py-3 text-xs text-flux-text-primary outline-none placeholder:text-flux-text-tertiary"
+          class="mt-4 block w-full rounded-2xl bg-flux-soft px-4 py-3 text-xs text-flux-text-primary placeholder:text-flux-text-tertiary"
           rows={2}
           placeholder="Notes (optional)"
           value={notes}

--- a/src/tabs/Workouts/components/Timer.tsx
+++ b/src/tabs/Workouts/components/Timer.tsx
@@ -65,23 +65,30 @@ export function Timer({ label, seconds, testId }: Props) {
     setFinished(false);
   }
 
+  const active = running || finished;
+
   return (
     <div
-      class="inline-flex items-center gap-2 rounded-md border border-flux-border bg-flux-soft px-2 py-1 text-xs"
+      class={
+        'inline-flex items-center gap-2 rounded-full px-3 py-1.5 transition-colors ' +
+        (active ? 'bg-flux-accent/20' : 'bg-flux-soft')
+      }
       data-testid={testId}
     >
-      <span class="font-mono uppercase tracking-wider text-flux-text-tertiary">{label}</span>
+      <span class="text-[9px] font-medium uppercase tracking-[0.18em] text-flux-text-tertiary">
+        {label}
+      </span>
       <span
         class={
-          'font-mono text-sm tabular-nums ' +
-          (finished ? 'text-flux-accent' : 'text-flux-text-primary')
+          'text-sm font-medium tabular-nums ' +
+          (finished ? 'text-flux-accent-dim' : 'text-flux-text-primary')
         }
       >
         {formatTime(remaining)}
       </span>
       <button
         type="button"
-        class="rounded border border-flux-border px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider text-flux-text-secondary hover:text-flux-text-primary disabled:opacity-40"
+        class="rounded-full bg-flux-card px-2.5 py-0.5 text-[10px] font-medium uppercase tracking-[0.15em] text-flux-text-secondary transition-colors hover:text-flux-text-primary disabled:opacity-40"
         onClick={startPause}
         disabled={finished}
       >
@@ -89,7 +96,7 @@ export function Timer({ label, seconds, testId }: Props) {
       </button>
       <button
         type="button"
-        class="rounded border border-flux-border px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wider text-flux-text-secondary hover:text-flux-text-primary"
+        class="rounded-full bg-flux-card px-2.5 py-0.5 text-[10px] font-medium uppercase tracking-[0.15em] text-flux-text-secondary transition-colors hover:text-flux-text-primary"
         onClick={reset}
       >
         Rst

--- a/src/tabs/Workouts/components/VideoModal.tsx
+++ b/src/tabs/Workouts/components/VideoModal.tsx
@@ -8,16 +8,16 @@ export function VideoModal({ videoId, start, onClose }: Props) {
   const startParam = start && start > 0 ? `&start=${start}` : '';
   return (
     <div
-      class="fixed inset-0 z-50 flex items-center justify-center bg-black/80 p-4"
+      class="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4 backdrop-blur-sm"
       onClick={(e) => {
         if (e.target === e.currentTarget) onClose();
       }}
       data-testid="video-modal"
     >
-      <div class="relative aspect-video w-full max-w-3xl overflow-hidden rounded-lg bg-black">
+      <div class="relative aspect-video w-full max-w-3xl overflow-hidden rounded-[2rem] bg-black shadow-flux-card">
         <button
           type="button"
-          class="absolute right-2 top-2 z-10 rounded-full border border-white/30 px-2 py-1 text-xs uppercase tracking-wider text-white hover:bg-white/10"
+          class="absolute right-3 top-3 z-10 rounded-full bg-flux-card/90 px-4 py-1.5 text-[10px] font-medium uppercase tracking-[0.18em] text-flux-text-primary transition-opacity hover:opacity-90"
           onClick={onClose}
         >
           Close

--- a/src/tabs/Workouts/index.tsx
+++ b/src/tabs/Workouts/index.tsx
@@ -174,7 +174,7 @@ export function Workouts() {
   if (!loaded) {
     return (
       <section class="flex h-full items-center justify-center">
-        <p class="text-sm text-flux-text-tertiary">Loading workout…</p>
+        <p class="text-xs uppercase tracking-[0.2em] text-flux-text-tertiary">Loading workout…</p>
       </section>
     );
   }
@@ -183,38 +183,44 @@ export function Workouts() {
   const progressPercent = totalExercises > 0 ? (completedCount / totalExercises) * 100 : 0;
 
   return (
-    <section class="mx-auto max-w-2xl space-y-4" data-testid="workouts-root">
-      <header class="space-y-1">
-        <h1 class="font-mono text-xs uppercase tracking-[0.2em] text-flux-text-tertiary">
+    <section class="mx-auto max-w-2xl space-y-6" data-testid="workouts-root">
+      <header class="flex flex-col items-center gap-2 pt-2 text-center">
+        <h1 class="text-sm font-medium uppercase tracking-[0.28em] text-flux-text-primary">
           Workouts
         </h1>
-        <div class="flex flex-wrap items-baseline gap-3">
-          <p class="font-mono text-xs text-flux-text-tertiary">
+        <div class="flex items-baseline gap-2 text-[10px] uppercase tracking-[0.2em] text-flux-text-tertiary">
+          <span>
             Day <span class="text-flux-text-primary" data-testid="day-counter">{state.globalDay}</span>
-            <span class="mx-1.5">·</span>
+          </span>
+          <span aria-hidden="true">·</span>
+          <span>
             Week <span class="text-flux-text-primary">{week}</span>
-          </p>
+          </span>
           {phase && (
-            <p class="text-xs text-flux-text-secondary" data-testid="phase-name">
-              {phase.name}
-            </p>
+            <>
+              <span aria-hidden="true">·</span>
+              <span data-testid="phase-name">{phase.name}</span>
+            </>
           )}
         </div>
       </header>
 
       {!program ? (
         <div
-          class="rounded-lg border border-flux-border bg-flux-card p-6 text-center"
+          class="rounded-[2rem] bg-flux-card p-8 text-center shadow-flux-card"
           data-testid="no-program"
         >
-          <h2 class="text-lg font-semibold text-flux-text-primary">No program loaded</h2>
-          <p class="mt-1 text-sm text-flux-text-secondary">
+          <p class="text-[10px] font-medium uppercase tracking-[0.2em] text-flux-text-tertiary">
+            Empty
+          </p>
+          <h2 class="mt-3 text-lg font-medium text-flux-text-primary">No program loaded</h2>
+          <p class="mt-2 text-sm text-flux-text-secondary">
             Programs are user-specific. Import one to begin, or generate with AI (coming soon).
           </p>
-          <div class="mt-4 flex flex-wrap justify-center gap-2">
+          <div class="mt-5 flex flex-wrap justify-center gap-2">
             <button
               type="button"
-              class="rounded border border-flux-accent bg-flux-accent/15 px-3 py-1.5 text-xs font-semibold uppercase tracking-wider text-flux-accent"
+              class="rounded-full bg-flux-accent px-5 py-2.5 text-[11px] font-medium uppercase tracking-[0.15em] text-flux-card shadow-flux-soft transition-opacity hover:opacity-90"
               onClick={triggerProgramImport}
               data-testid="import-program-btn"
             >
@@ -222,12 +228,12 @@ export function Workouts() {
             </button>
             <button
               type="button"
-              class="cursor-not-allowed rounded border border-flux-border bg-flux-soft px-3 py-1.5 text-xs font-medium uppercase tracking-wider text-flux-text-tertiary"
+              class="cursor-not-allowed rounded-full bg-flux-soft px-5 py-2.5 text-[11px] font-medium uppercase tracking-[0.15em] text-flux-text-tertiary"
               disabled
               data-testid="generate-ai-btn"
               title="AI program generation is on the roadmap."
             >
-              Generate with AI (coming soon)
+              Generate with AI (soon)
             </button>
           </div>
           <input
@@ -241,27 +247,33 @@ export function Workouts() {
       ) : workout ? (
         <>
           <div
-            class="overflow-hidden rounded-lg border border-flux-border bg-flux-card"
+            class="overflow-hidden rounded-[2rem] bg-flux-card p-6 shadow-flux-card"
             data-testid="workout-card"
           >
-            <div class="border-b border-flux-border p-4">
-              <h2 class="text-lg font-semibold text-flux-text-primary" data-testid="workout-name">
-                {workout.name}
-              </h2>
-              <p class="mt-0.5 text-xs uppercase tracking-wider text-flux-text-tertiary">
-                {workout.focus}
-              </p>
-            </div>
-            <div class="h-1 bg-flux-soft">
-              <div
-                class="h-full bg-flux-accent transition-all"
-                style={{ width: `${progressPercent}%` }}
-                data-testid="session-progress"
-              />
+            <p class="text-[10px] font-medium uppercase tracking-[0.2em] text-flux-text-tertiary">
+              {workout.focus}
+            </p>
+            <h2
+              class="mt-2 text-2xl font-medium leading-tight text-flux-text-primary"
+              data-testid="workout-name"
+            >
+              {workout.name}
+            </h2>
+            <div class="mt-5 flex items-center gap-3">
+              <div class="h-1.5 flex-1 overflow-hidden rounded-full bg-flux-soft">
+                <div
+                  class="h-full rounded-full bg-flux-accent transition-all"
+                  style={{ width: `${progressPercent}%` }}
+                  data-testid="session-progress"
+                />
+              </div>
+              <span class="text-[10px] font-medium uppercase tracking-[0.15em] tabular-nums text-flux-text-tertiary">
+                {completedCount}/{totalExercises}
+              </span>
             </div>
           </div>
 
-          <div class="space-y-3" data-testid="exercises-list">
+          <div class="space-y-4" data-testid="exercises-list">
             {resolvedExercises.map((ex, i) => {
               const key = `${state.globalDay}_${i}`;
               const last = latestWeights.get(ex.name) ?? null;
@@ -291,20 +303,23 @@ export function Workouts() {
         </>
       ) : (
         <div
-          class="rounded-lg border border-flux-border bg-flux-card p-6 text-center"
+          class="rounded-[2rem] bg-flux-card p-8 text-center shadow-flux-card"
           data-testid="rest-day"
         >
-          <h2 class="text-lg font-semibold text-flux-text-primary">Rest day</h2>
-          <p class="mt-1 text-sm text-flux-text-secondary">
+          <p class="text-[10px] font-medium uppercase tracking-[0.2em] text-flux-text-tertiary">
+            Today
+          </p>
+          <h2 class="mt-3 text-2xl font-medium text-flux-text-primary">Rest day</h2>
+          <p class="mt-2 text-sm text-flux-text-secondary">
             Recovery is part of the program. Mobility welcome.
           </p>
         </div>
       )}
 
-      <div class="flex flex-wrap items-center gap-2 border-t border-flux-border pt-4">
+      <div class="flex flex-wrap items-center gap-2 pt-2">
         <button
           type="button"
-          class="rounded border border-flux-border bg-flux-soft px-3 py-1.5 text-xs font-medium uppercase tracking-wider text-flux-text-secondary hover:text-flux-text-primary"
+          class="rounded-full bg-flux-card px-4 py-2 text-[11px] font-medium uppercase tracking-[0.15em] text-flux-text-secondary shadow-flux-soft transition-opacity hover:text-flux-text-primary disabled:opacity-40"
           onClick={prevDay}
           disabled={state.globalDay <= 1}
           data-testid="prev-day"
@@ -313,7 +328,7 @@ export function Workouts() {
         </button>
         <button
           type="button"
-          class="rounded border border-flux-accent bg-flux-accent/15 px-3 py-1.5 text-xs font-semibold uppercase tracking-wider text-flux-accent"
+          class="rounded-full bg-flux-accent px-5 py-2 text-[11px] font-medium uppercase tracking-[0.15em] text-flux-card shadow-flux-soft transition-opacity hover:opacity-90"
           onClick={nextDay}
           data-testid="next-day"
         >
@@ -323,7 +338,7 @@ export function Workouts() {
 
       {importMessage && (
         <div
-          class="flex items-start justify-between gap-2 rounded border border-flux-border bg-flux-card px-3 py-2 text-xs text-flux-text-secondary"
+          class="flex items-start justify-between gap-2 rounded-2xl bg-flux-card px-4 py-3 text-xs text-flux-text-secondary shadow-flux-soft"
           data-testid="program-import-message"
         >
           <span class="flex-1">{importMessage}</span>

--- a/src/tabs/Workouts/index.tsx
+++ b/src/tabs/Workouts/index.tsx
@@ -220,7 +220,7 @@ export function Workouts() {
           <div class="mt-5 flex flex-wrap justify-center gap-2">
             <button
               type="button"
-              class="rounded-full bg-flux-accent px-5 py-2.5 text-[11px] font-medium uppercase tracking-[0.15em] text-flux-card shadow-flux-soft transition-opacity hover:opacity-90"
+              class="rounded-full bg-flux-accent px-5 py-2.5 text-[11px] font-medium uppercase tracking-[0.15em] text-flux-accent-fg shadow-flux-soft transition-opacity hover:opacity-90"
               onClick={triggerProgramImport}
               data-testid="import-program-btn"
             >
@@ -328,7 +328,7 @@ export function Workouts() {
         </button>
         <button
           type="button"
-          class="rounded-full bg-flux-accent px-5 py-2 text-[11px] font-medium uppercase tracking-[0.15em] text-flux-card shadow-flux-soft transition-opacity hover:opacity-90"
+          class="rounded-full bg-flux-accent px-5 py-2 text-[11px] font-medium uppercase tracking-[0.15em] text-flux-accent-fg shadow-flux-soft transition-opacity hover:opacity-90"
           onClick={nextDay}
           data-testid="next-day"
         >

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -20,8 +20,12 @@ export default {
         },
       },
       fontFamily: {
-        mono: ['JetBrains Mono', 'ui-monospace', 'SF Mono', 'Menlo', 'monospace'],
-        sans: ['Inter Tight', 'Inter', 'system-ui', '-apple-system', 'Segoe UI', 'sans-serif'],
+        sans: ['Inter', 'ui-sans-serif', 'system-ui', '-apple-system', 'Segoe UI', 'sans-serif'],
+      },
+      boxShadow: {
+        'flux-card': '0 8px 30px rgba(0, 0, 0, 0.04)',
+        'flux-soft': '0 4px 20px rgba(0, 0, 0, 0.03)',
+        'flux-nav': '0 -4px 30px rgba(0, 0, 0, 0.04)',
       },
     },
   },

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,6 +8,7 @@ export default {
         flux: {
           accent: 'var(--flux-accent)',
           'accent-dim': 'var(--flux-accent-dim)',
+          'accent-fg': 'var(--flux-accent-fg)',
           bg: 'var(--flux-bg)',
           card: 'var(--flux-card)',
           soft: 'var(--flux-soft)',


### PR DESCRIPTION
## Summary

This is a **design prototype for preview** — not a final implementation. The goal is to re-skin every visible flux surface in the visual language of `balance` so you can react before we commit to anything.

**No functional changes.** All logic, state, IndexedDB schemas, tests, accessibility attrs, and \`data-testid\`s are untouched.

## Palette

| Token | Hex | Role |
|-------|-----|------|
| sage | \`#dce3d0\` | app background (light) |
| cream | \`#f4f3ea\` | primary card surface |
| sand | \`#e8e6dd\` | secondary surface (inputs, soft chips) |
| forest | \`#4a534b\` | primary text + dark accent button |
| mint | \`#a2b8ad\` | call-to-action surfaces, completed states |

The five tokens map onto the existing \`flux-*\` Tailwind names via CSS variables, so the diff stays a re-point rather than a rename. You can dial any single token in \`src/index.css\` and the whole UI follows.

## Dark mode (derived)

Balance ships light-only, so I had to invent a dark variant. I aimed to **keep the warm/earthy spirit** instead of reverting to flux's old Pareto-grey. Specific choices:

| Token | Value | Note |
|-------|-------|------|
| bg | \`#2a302b\` | deep muted green |
| card | \`#363d37\` | one step warmer |
| soft | \`#3f4740\` | inputs / chips |
| text-primary | \`#ece9dc\` | dimmed cream (AA on card) |
| text-secondary | \`rgba(184,196,188,0.92)\` | mint-cream |
| text-tertiary | \`rgba(162,184,173,0.72)\` | dimmed mint |
| accent | \`#a2b8ad\` | mint, shared with light |

Tell me if dark feels too green / too dark / not enough contrast and I'll dial specific tokens.

## Style signatures applied

- **Cards**: \`rounded-[2rem]\`, soft \`shadow-flux-card\` (\`0 8px 30px rgba(0,0,0,0.04)\`), no visible borders — surfaces float on shadow.
- **Buttons / chips**: \`rounded-full\`, mint for call-to-action, sand for neutral.
- **Headings & labels**: uppercase, \`tracking-[0.18em]\`–\`tracking-[0.28em]\`, weight 500. Body copy stays sentence-case.
- **Tab nav**: floating rounded-full pill pinned to bottom; selected tab uses mint. Replaces the flat border-t bar.
- **Typography**: Inter only (400/500/600). Dropped JetBrains Mono + \`Inter Tight\`; no \`font-mono\` references remain in source.
- **Workout focus stat strip**: sets / reps / rest are now a centered 3-column block on a sand background, with divider lines, instead of inline mono text.
- **Done button & difficulty chips**: mint when active.
- **Meditate / Check-in stubs**: each gets an intentional empty-state card (decorative element + uppercase label + sentence) rather than a placeholder line.
- **Settings**: dark/light toggle restyled as a segmented pill but still wired to the same \`data-mode\` attribute — your existing toggle still works.

## What I deliberately did **not** do

- **No desktop phone-frame**: balance's \`rounded-[3rem]\` 390×844 mobile-shaped frame is a desktop framing trick. Flux runs full-viewport on Android / PWA, so the frame would actively hurt; we get the *materials* (color / shape / type) without the *staging*.
- **No new dependencies**: did not add \`lucide-react\` (React-only — flux is Preact). The few icons used are unicode (✓ ← →) or simple SVG-free shapes.
- **No Tailwind v4 upgrade**: balance is v4, flux stays v3 — porting v3-compatible classes is sufficient.
- **No logic, state, or test edits**: all tests still pass.

## Invitation

If any of this lands wrong — too soft, too rounded, too green in dark, wrong tab-nav shape, anything — tell me **which surface or which token** and I'll dial it. The whole skin is variable-driven so single-token tweaks ripple everywhere.

## Test plan

- [x] \`nix develop --command npm run typecheck\` — clean
- [x] \`nix develop --command npm run build\` — clean (51 KB JS, 13 KB CSS)
- [x] \`nix develop .#test --command npx playwright test --project=chromium\` — 14/14 pass
- [ ] Spot-check both modes in a browser — open Settings, toggle dark/light, walk through Workouts/Meditate/Check-in/Settings

Run: 20260518-2117-78d7d568