### PR TITLE
scripts: add local-install.sh for one-step build + adb install

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,2 @@
+use flake
+PATH_add bin

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 dist/
+.direnv/
 playwright-report/
 test-results/
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -48,6 +48,22 @@ CI builds the APK via `setup-java` + `setup-android` in
 `.github/workflows/test.yml` rather than this nix shell — the toolchains are
 decoupled intentionally.
 
+## Local Android install
+
+Build and install the debug APK on a connected device (USB or Android Studio
+wireless debugging):
+
+```
+nix develop .#android --command ./scripts/local-install.sh
+```
+
+The script: `npm ci` → `vite build` → `cap sync` → `./gradlew assembleDebug` →
+`adb install -r`. First gradle run pulls AGP + AndroidX deps (a few minutes);
+subsequent runs are fast. If install fails with a signature mismatch (a
+previously-installed CI build has a different debug keystore),
+`adb uninstall dev.gunk.flux` and re-run — your IndexedDB data will be wiped,
+so export a backup first via Settings → Data → Export if it matters.
+
 ## Project layout
 
 ```

--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ app (`adb uninstall <appId>`, where `<appId>` is the `appId` from
 data will be wiped, so export a backup first via Settings → Data → Export if
 it matters.
 
+**With direnv:** the repo includes a `.envrc` that auto-loads the default dev
+shell on `cd`. The first time you enter the directory after pulling this
+change, run `direnv allow` once. From then on, you can run `flux-install`
+directly from anywhere inside the repo — it's a wrapper that invokes the
+android dev shell and runs `scripts/local-install.sh` for you.
+
 ## Project layout
 
 ```

--- a/README.md
+++ b/README.md
@@ -57,12 +57,14 @@ wireless debugging):
 nix develop .#android --command ./scripts/local-install.sh
 ```
 
-The script: `npm ci` → `vite build` → `cap sync` → `./gradlew assembleDebug` →
+The script: `npm install` → `vite build` → `cap sync` → `./gradlew assembleDebug` →
 `adb install -r`. First gradle run pulls AGP + AndroidX deps (a few minutes);
 subsequent runs are fast. If install fails with a signature mismatch (a
-previously-installed CI build has a different debug keystore),
-`adb uninstall dev.gunk.flux` and re-run — your IndexedDB data will be wiped,
-so export a backup first via Settings → Data → Export if it matters.
+previously-installed CI build has a different debug keystore), uninstall the
+app (`adb uninstall <appId>`, where `<appId>` is the `appId` from
+`capacitor.config.ts` — currently `dev.gunk.flux`) and re-run. Your IndexedDB
+data will be wiped, so export a backup first via Settings → Data → Export if
+it matters.
 
 ## Project layout
 

--- a/bin/flux-install
+++ b/bin/flux-install
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Wrapper that invokes scripts/local-install.sh inside the .#android
+# nix dev shell. PATH_add'd via .envrc so this is available as 'flux-install'
+# anywhere inside the flux repo.
+set -euo pipefail
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+exec nix develop "${REPO_ROOT}#android" --command "${REPO_ROOT}/scripts/local-install.sh" "$@"

--- a/scripts/local-install.sh
+++ b/scripts/local-install.sh
@@ -7,6 +7,9 @@
 #   nix develop .#android --command ./scripts/local-install.sh
 set -euo pipefail
 
+# Keep in sync with appId in capacitor.config.ts.
+APP_ID="dev.gunk.flux"
+
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT"
 
@@ -15,8 +18,8 @@ if [[ -z "${ANDROID_HOME:-}" ]]; then
   exit 2
 fi
 
-echo '[1/4] npm ci'
-npm ci
+echo '[1/4] npm install'
+npm install
 
 echo '[2/4] vite build'
 npm run build
@@ -25,17 +28,23 @@ echo '[3/4] cap sync android'
 npx cap sync android
 
 echo '[4/4] gradle assembleDebug + adb install'
-(cd android && ./gradlew assembleDebug --no-daemon)
+(cd android && ./gradlew assembleDebug)
 
 APK=android/app/build/outputs/apk/debug/app-debug.apk
 [[ -f "$APK" ]] || { echo "error: APK not produced at $APK" >&2; exit 1; }
+
+if ! adb get-state >/dev/null 2>&1; then
+  echo "error: no device connected or multiple devices visible to adb." >&2
+  echo "       run 'adb devices' to check, then connect a single device." >&2
+  exit 1
+fi
 
 if ! adb install -r "$APK"; then
   echo ""
   echo "install failed — most likely cause: previously installed APK has a different signature"
   echo "  (e.g. a CI debug build). To recover (will wipe app data):"
   echo ""
-  echo "  adb uninstall dev.gunk.flux"
+  echo "  adb uninstall $APP_ID"
   echo "  ./scripts/local-install.sh"
   echo ""
   echo "Export your data first via Settings → Data → Export if you want to preserve workout state."

--- a/scripts/local-install.sh
+++ b/scripts/local-install.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Build the web bundle, sync into the Capacitor android project, build the
+# debug APK, and install it on whichever device is currently visible to adb
+# (USB or wireless-debugging via Android Studio).
+#
+# Run from the repo root inside the .#android dev shell:
+#   nix develop .#android --command ./scripts/local-install.sh
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+if [[ -z "${ANDROID_HOME:-}" ]]; then
+  echo "error: ANDROID_HOME not set — run inside 'nix develop .#android'" >&2
+  exit 2
+fi
+
+echo '[1/4] npm ci'
+npm ci
+
+echo '[2/4] vite build'
+npm run build
+
+echo '[3/4] cap sync android'
+npx cap sync android
+
+echo '[4/4] gradle assembleDebug + adb install'
+(cd android && ./gradlew assembleDebug --no-daemon)
+
+APK=android/app/build/outputs/apk/debug/app-debug.apk
+[[ -f "$APK" ]] || { echo "error: APK not produced at $APK" >&2; exit 1; }
+
+if ! adb install -r "$APK"; then
+  echo ""
+  echo "install failed — most likely cause: previously installed APK has a different signature"
+  echo "  (e.g. a CI debug build). To recover (will wipe app data):"
+  echo ""
+  echo "  adb uninstall dev.gunk.flux"
+  echo "  ./scripts/local-install.sh"
+  echo ""
+  echo "Export your data first via Settings → Data → Export if you want to preserve workout state."
+  exit 1
+fi
+
+echo ""
+echo "installed: $APK"


### PR DESCRIPTION
## Summary

Adds `scripts/local-install.sh` — a single-command helper that runs
`npm ci` → `vite build` → `npx cap sync android` → `./gradlew assembleDebug` →
`adb install -r` against whatever device adb currently sees (USB or
Android Studio wireless debugging).

Usage:

```
nix develop .#android --command ./scripts/local-install.sh
```

**With direnv:** the repo now ships a `.envrc` (`use flake` + `PATH_add bin`)
and a `bin/flux-install` wrapper. After `direnv allow` on first entry, you can
just run `flux-install` from anywhere inside the repo — it invokes the
`.#android` dev shell and runs `scripts/local-install.sh` for you. The default
`.envrc` shell is intentionally the light dev shell (not `.#android`), so a
bare `cd` doesn't force the multi-GB Android SDK fetch on web-only work.

The script bails early if `ANDROID_HOME` isn't set (i.e. run outside the
`.#android` shell), and prints a recovery hint with `adb uninstall dev.gunk.flux`
when install fails with a signature mismatch against a previously-installed CI
build. README has a matching "Local Android install" section.

This is purely dev-experience tooling — no production or CI behavior change.
CI's `build-android` job in `test.yml` is untouched, and the script lives
outside `package.json` scripts on purpose so it's clear it needs the Nix shell.

## Test plan

- [x] `bash -n scripts/local-install.sh` passes
- [x] `shellcheck scripts/local-install.sh` is clean
- [x] `bash -n bin/flux-install` passes
- [x] `shellcheck bin/flux-install` is clean
- [x] Executable bit committed (`100755` in the tree) for both scripts
- [x] `.direnv/` added to `.gitignore`
- [x] `klaus _pre-review` clean

Run: 20260519-1520-7327b58c