### PR TITLE
flake: add adb to default dev shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -27,6 +27,7 @@
           buildInputs = with pkgs; [
             nodejs_20
             nixfmt-rfc-style
+            android-tools
             klaus.packages.${system}.default
           ];
 
@@ -36,6 +37,7 @@
             echo "  npm ci             - Install dependencies"
             echo "  npm run dev        - Vite dev server"
             echo "  npm run build      - Production build to dist/"
+            echo "  adb devices        - list connected Android devices"
           '';
         };
 


### PR DESCRIPTION
## Summary

Adds `android-tools` (the standalone `adb`/`fastboot` package from nixpkgs) to `devShells.default` in `flake.nix`, so `adb` is available from a plain `nix develop` without entering `devShells.android`.

`devShells.android` already provides `adb` via the full Android SDK, but that pulls multi-GB unfree SDK components. `android-tools` is a small standalone build of the platform tools — no SDK and no unfree licensing needed — making it cheap enough to include by default.

Also adds a one-line `adb devices` hint to the default shell's `shellHook` banner.

## Test plan

- [x] `nix develop --command adb --version` succeeds in a fresh shell (reports `1.0.41`, `35.0.2-android-tools`)
- [x] `flake.nix` stays formatted under `nixfmt-rfc-style`
- [x] `devShells.test`, `devShells.android`, and `packages.default` are untouched

Run: 20260521-0654-1b56f68f