### PR TITLE
Add equipment inventory store, Settings UI, and constrained weight picker

### DIFF
--- a/src/data/inventory.ts
+++ b/src/data/inventory.ts
@@ -1,0 +1,55 @@
+// Per-user equipment inventory. The Workouts state.ts persists this in a
+// 'inventory' IDB store under the key 'current'. Wrapped in a LocationsState
+// so future work can add multi-location support (gym vs home vs travel) without
+// another migration — PR-B only ever edits the active location.
+
+import type { EquipmentKind } from './equipmentCatalog';
+
+export interface InventoryItem {
+  kind: EquipmentKind;
+  // Discrete weights the user owns, in lbs. Empty array for kinds where
+  // hasWeightSelection is false (TRX, pullup bar, bodyweight, etc.).
+  ownedWeights: number[];
+  note?: string;
+}
+
+export type Inventory = Partial<Record<EquipmentKind, InventoryItem>>;
+
+export interface Location {
+  id: string;
+  name: string;
+  inventory: Inventory;
+}
+
+export interface LocationsState {
+  locations: Record<string, Location>;
+  activeLocationId: string;
+}
+
+export const DEFAULT_LOCATIONS_STATE: LocationsState = {
+  locations: { default: { id: 'default', name: 'Home', inventory: {} } },
+  activeLocationId: 'default',
+};
+
+export function cloneDefaultLocationsState(): LocationsState {
+  return {
+    locations: {
+      default: { id: 'default', name: 'Home', inventory: {} },
+    },
+    activeLocationId: 'default',
+  };
+}
+
+// Convenience selector — read the inventory of the active location.
+export function activeInventory(state: LocationsState): Inventory {
+  return state.locations[state.activeLocationId]?.inventory ?? {};
+}
+
+// True when the user has populated inventory in any location. Used to
+// gate constrained-picker behaviour — first-run users keep the old free
+// input until they've configured something.
+export function isInventoryConfigured(state: LocationsState): boolean {
+  return Object.values(state.locations).some(
+    (loc) => Object.keys(loc.inventory).length > 0,
+  );
+}

--- a/src/tabs/Settings.tsx
+++ b/src/tabs/Settings.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'preact/hooks';
+import { useEffect, useMemo, useRef, useState } from 'preact/hooks';
 import { useLLM } from '../llm';
 import {
   applyImportFromFile,
@@ -6,7 +6,23 @@ import {
   exportPayload,
   formatImportMessage,
 } from './Workouts/logic/exportImport';
-import { clearAll } from './Workouts/state';
+import {
+  clearAll,
+  loadLocations,
+  saveLocations,
+} from './Workouts/state';
+import {
+  EQUIPMENT_CATALOG,
+  type EquipmentItem,
+  type EquipmentKind,
+} from '../data/equipmentCatalog';
+import {
+  activeInventory,
+  cloneDefaultLocationsState,
+  type Inventory,
+  type InventoryItem,
+  type LocationsState,
+} from '../data/inventory';
 
 const MODE_STORAGE_KEY = 'flux_mode';
 type Mode = 'dark' | 'light';
@@ -31,14 +47,73 @@ function applyMode(mode: Mode): void {
   }
 }
 
+const CATEGORY_ORDER: EquipmentItem['category'][] = [
+  'free-weight',
+  'fixed',
+  'cardio',
+  'accessory',
+];
+
+const CATEGORY_LABEL: Record<EquipmentItem['category'], string> = {
+  'free-weight': 'Free weight',
+  fixed: 'Fixed',
+  cardio: 'Cardio',
+  accessory: 'Accessory',
+  sentinel: 'Sentinel',
+};
+
+interface Preset {
+  label: string;
+  weights: number[];
+}
+
+const PRESETS: Partial<Record<EquipmentKind, Preset[]>> = {
+  kettlebell: [
+    { label: 'Common set (25/35/45)', weights: [25, 35, 45] },
+    { label: 'Light (10/15/20)', weights: [10, 15, 20] },
+    { label: 'Heavy (35/45/55/70)', weights: [35, 45, 55, 70] },
+  ],
+  dumbbell: [
+    { label: 'Adjustable 5–50 by 5', weights: range(5, 50, 5) },
+    { label: 'Adjustable 5–90 by 5', weights: range(5, 90, 5) },
+  ],
+  barbell: [
+    { label: 'Olympic + plates', weights: [45, 65, 85, 95, 115, 135, 155, 185] },
+  ],
+};
+
+function range(from: number, to: number, step: number): number[] {
+  const out: number[] = [];
+  for (let v = from; v <= to; v += step) out.push(v);
+  return out;
+}
+
+function normalizeWeights(arr: number[]): number[] {
+  const seen = new Set<number>();
+  for (const w of arr) if (Number.isFinite(w) && w > 0) seen.add(w);
+  return Array.from(seen).sort((a, b) => a - b);
+}
+
 export function Settings() {
   const { available } = useLLM();
   const [mode, setMode] = useState<Mode>(detectInitialMode);
   const [importMessage, setImportMessage] = useState<string | null>(null);
+  const [locations, setLocations] = useState<LocationsState>(
+    cloneDefaultLocationsState,
+  );
+  const [locationsLoaded, setLocationsLoaded] = useState(false);
 
   useEffect(() => {
     applyMode(mode);
   }, [mode]);
+
+  useEffect(() => {
+    (async () => {
+      const loc = await loadLocations();
+      setLocations(loc);
+      setLocationsLoaded(true);
+    })();
+  }, []);
 
   async function handleExport() {
     const payload = await exportPayload();
@@ -53,6 +128,9 @@ export function Settings() {
     try {
       const result = await applyImportFromFile(file, { applyState: true });
       setImportMessage(formatImportMessage(result));
+      // Reload locations in case the import restored inventory.
+      const loc = await loadLocations();
+      setLocations(loc);
     } catch (err) {
       setImportMessage(
         'Import failed: ' + (err instanceof Error ? err.message : 'unknown error'),
@@ -65,12 +143,86 @@ export function Settings() {
     try {
       await clearAll();
       setImportMessage('Reset complete.');
+      setLocations(cloneDefaultLocationsState());
     } catch (err) {
       setImportMessage(
         'Reset failed: ' + (err instanceof Error ? err.message : 'unknown error'),
       );
     }
   }
+
+  const inventory = useMemo(() => activeInventory(locations), [locations]);
+
+  function persistLocations(next: LocationsState) {
+    setLocations(next);
+    saveLocations(next).catch(() => {});
+  }
+
+  function updateInventory(next: Inventory) {
+    const activeId = locations.activeLocationId;
+    const current = locations.locations[activeId];
+    if (!current) return;
+    const nextLocations: LocationsState = {
+      ...locations,
+      locations: {
+        ...locations.locations,
+        [activeId]: { ...current, inventory: next },
+      },
+    };
+    persistLocations(nextLocations);
+  }
+
+  function toggleOwned(kind: EquipmentKind) {
+    const cat = EQUIPMENT_CATALOG[kind];
+    if (inventory[kind]) {
+      const { [kind]: _removed, ...rest } = inventory;
+      void _removed;
+      updateInventory(rest);
+    } else {
+      updateInventory({
+        ...inventory,
+        [kind]: {
+          kind,
+          ownedWeights: cat.hasWeightSelection ? [] : [],
+        },
+      });
+    }
+  }
+
+  function setWeights(kind: EquipmentKind, weights: number[]) {
+    const current = inventory[kind];
+    if (!current) return;
+    updateInventory({
+      ...inventory,
+      [kind]: { ...current, ownedWeights: normalizeWeights(weights) },
+    });
+  }
+
+  function setNote(kind: EquipmentKind, note: string) {
+    const current = inventory[kind];
+    if (!current) return;
+    const trimmed = note.trim();
+    updateInventory({
+      ...inventory,
+      [kind]: {
+        ...current,
+        note: trimmed ? trimmed : undefined,
+      },
+    });
+  }
+
+  const visibleKinds = useMemo(
+    () =>
+      (Object.values(EQUIPMENT_CATALOG) as EquipmentItem[])
+        .filter((e) => e.id !== 'bodyweight')
+        .sort((a, b) => {
+          const ai = CATEGORY_ORDER.indexOf(a.category);
+          const bi = CATEGORY_ORDER.indexOf(b.category);
+          if (ai !== bi) return ai - bi;
+          return a.name.localeCompare(b.name);
+        }),
+    [],
+  );
 
   return (
     <section class="mx-auto max-w-md space-y-5">
@@ -114,6 +266,49 @@ export function Settings() {
         <p class="mt-3 text-sm text-flux-text-secondary">
           {available ? 'Configured' : 'Not configured'}
         </p>
+      </div>
+
+      <div
+        class="rounded-[2rem] bg-flux-card p-6 shadow-flux-card"
+        data-testid="equipment-section"
+      >
+        <h2 class="text-[10px] font-medium uppercase tracking-[0.2em] text-flux-text-tertiary">
+          Equipment
+        </h2>
+        <p class="mt-2 text-xs text-flux-text-secondary">
+          What you have available for workouts. Programs and weight pickers respect this.
+        </p>
+        {!locationsLoaded ? (
+          <p class="mt-4 text-[11px] uppercase tracking-[0.18em] text-flux-text-tertiary">
+            Loading…
+          </p>
+        ) : (
+          <div class="mt-5 space-y-5">
+            {CATEGORY_ORDER.map((cat) => {
+              const inCat = visibleKinds.filter((k) => k.category === cat);
+              if (inCat.length === 0) return null;
+              return (
+                <div key={cat} class="space-y-3">
+                  <h3 class="text-[10px] font-medium uppercase tracking-[0.18em] text-flux-text-tertiary">
+                    {CATEGORY_LABEL[cat]}
+                  </h3>
+                  <div class="space-y-3">
+                    {inCat.map((kind) => (
+                      <EquipmentRow
+                        key={kind.id}
+                        item={kind}
+                        owned={inventory[kind.id]}
+                        onToggle={() => toggleOwned(kind.id)}
+                        onSetWeights={(ws) => setWeights(kind.id, ws)}
+                        onSetNote={(n) => setNote(kind.id, n)}
+                      />
+                    ))}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
       </div>
 
       <div class="rounded-[2rem] bg-flux-card p-6 shadow-flux-card">
@@ -176,5 +371,161 @@ export function Settings() {
         </div>
       </div>
     </section>
+  );
+}
+
+interface RowProps {
+  item: EquipmentItem;
+  owned: InventoryItem | undefined;
+  onToggle: () => void;
+  onSetWeights: (next: number[]) => void;
+  onSetNote: (next: string) => void;
+}
+
+function EquipmentRow({ item, owned, onToggle, onSetWeights, onSetNote }: RowProps) {
+  const ownedFlag = owned !== undefined;
+  const weights = owned?.ownedWeights ?? [];
+  const presets = PRESETS[item.id] ?? [];
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const [draft, setDraft] = useState('');
+  const [presetIdx, setPresetIdx] = useState('');
+
+  function addWeight() {
+    const parsed = parseFloat(draft);
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+      setDraft('');
+      return;
+    }
+    onSetWeights([...weights, parsed]);
+    setDraft('');
+    inputRef.current?.focus();
+  }
+
+  function removeWeight(w: number) {
+    onSetWeights(weights.filter((x) => x !== w));
+  }
+
+  function applyPreset(value: string) {
+    const idx = Number(value);
+    setPresetIdx('');
+    if (!Number.isInteger(idx) || idx < 0 || idx >= presets.length) return;
+    const merged = [...weights, ...presets[idx].weights];
+    onSetWeights(merged);
+  }
+
+  return (
+    <div
+      class="rounded-2xl bg-flux-soft px-4 py-3"
+      data-testid={`equipment-row-${item.id}`}
+    >
+      <div class="flex items-center justify-between gap-3">
+        <span class="text-sm font-medium text-flux-text-primary">{item.name}</span>
+        <button
+          type="button"
+          role="switch"
+          aria-checked={ownedFlag}
+          onClick={onToggle}
+          data-testid={`equipment-toggle-${item.id}`}
+          class={
+            'rounded-full px-3 py-1 text-[10px] font-medium uppercase tracking-[0.15em] transition-colors ' +
+            (ownedFlag
+              ? 'bg-flux-accent text-flux-accent-fg shadow-flux-soft'
+              : 'bg-flux-card text-flux-text-secondary hover:text-flux-text-primary')
+          }
+        >
+          {ownedFlag ? 'Owned' : 'Off'}
+        </button>
+      </div>
+
+      {ownedFlag && item.hasWeightSelection && (
+        <div class="mt-3 space-y-3">
+          <div
+            class="flex flex-wrap gap-1.5"
+            data-testid={`equipment-chips-${item.id}`}
+          >
+            {weights.length === 0 ? (
+              <span class="text-[11px] uppercase tracking-[0.15em] text-flux-text-tertiary">
+                No weights yet
+              </span>
+            ) : (
+              weights.map((w) => (
+                <span
+                  key={w}
+                  class="inline-flex items-center gap-1 rounded-full bg-flux-card px-2.5 py-1 text-[11px] font-medium tabular-nums text-flux-text-primary"
+                  data-testid={`equipment-chip-${item.id}-${w}`}
+                >
+                  {w}
+                  <button
+                    type="button"
+                    onClick={() => removeWeight(w)}
+                    aria-label={`Remove ${w}`}
+                    class="text-flux-text-tertiary hover:text-flux-danger"
+                    data-testid={`equipment-chip-remove-${item.id}-${w}`}
+                  >
+                    ×
+                  </button>
+                </span>
+              ))
+            )}
+          </div>
+
+          <div class="flex flex-wrap items-center gap-2">
+            <input
+              ref={inputRef}
+              type="number"
+              min={0}
+              step="any"
+              class="w-20 rounded-xl bg-flux-card px-3 py-1.5 text-center text-sm font-medium tabular-nums text-flux-text-primary placeholder:text-flux-text-tertiary"
+              placeholder="lbs"
+              value={draft}
+              onInput={(e) => setDraft((e.target as HTMLInputElement).value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  e.preventDefault();
+                  addWeight();
+                }
+              }}
+              data-testid={`equipment-weight-input-${item.id}`}
+            />
+            <button
+              type="button"
+              onClick={addWeight}
+              class="rounded-full bg-flux-card px-3 py-1.5 text-[11px] font-medium uppercase tracking-[0.15em] text-flux-text-secondary transition-colors hover:text-flux-text-primary"
+              data-testid={`equipment-weight-add-${item.id}`}
+            >
+              Add
+            </button>
+            {presets.length > 0 && (
+              <select
+                value={presetIdx}
+                onChange={(e) =>
+                  applyPreset((e.target as HTMLSelectElement).value)
+                }
+                class="rounded-full bg-flux-card px-3 py-1.5 text-[11px] font-medium uppercase tracking-[0.15em] text-flux-text-secondary"
+                data-testid={`equipment-preset-${item.id}`}
+              >
+                <option value="">+ preset…</option>
+                {presets.map((p, i) => (
+                  <option key={p.label} value={String(i)}>
+                    {p.label}
+                  </option>
+                ))}
+              </select>
+            )}
+          </div>
+        </div>
+      )}
+
+      {ownedFlag && (
+        <input
+          type="text"
+          value={owned?.note ?? ''}
+          placeholder="Note (optional)"
+          onChange={(e) => onSetNote((e.target as HTMLInputElement).value)}
+          class="mt-3 w-full rounded-xl bg-flux-card px-3 py-1.5 text-xs text-flux-text-primary placeholder:text-flux-text-tertiary"
+          data-testid={`equipment-note-${item.id}`}
+        />
+      )}
+    </div>
   );
 }

--- a/src/tabs/Workouts/components/ExerciseCard.tsx
+++ b/src/tabs/Workouts/components/ExerciseCard.tsx
@@ -10,6 +10,11 @@ interface Props {
   entry: LogEntry | undefined;
   suggestedWeight: number | null;
   lastWeight: number | null;
+  // List of weights the user is allowed to pick for this exercise. null when
+  // the exercise has no weight, or when the user hasn't configured inventory
+  // yet (free-input fallback).
+  allowedWeights?: number[] | null;
+  inventoryConfigured?: boolean;
   onLog: (key: string, partial: Partial<LogEntry>, options?: { remove?: boolean }) => void;
   onPlayVideo: (videoId: string, start?: number) => void;
 }
@@ -21,6 +26,8 @@ export function ExerciseCard({
   entry,
   suggestedWeight,
   lastWeight,
+  allowedWeights = null,
+  inventoryConfigured = false,
   onLog,
   onPlayVideo,
 }: Props) {
@@ -104,6 +111,44 @@ export function ExerciseCard({
 
   const placeholder = suggestedWeight != null ? String(suggestedWeight) : lastWeight != null ? String(lastWeight) : '—';
 
+  const useChipPicker =
+    inventoryConfigured && Array.isArray(allowedWeights) && allowedWeights.length > 0;
+  const inventoryEmptyForExercise =
+    inventoryConfigured && Array.isArray(allowedWeights) && allowedWeights.length === 0;
+  const chipWeights: number[] = useChipPicker ? [...(allowedWeights as number[])] : [];
+  const weightIsDrift =
+    useChipPicker &&
+    typeof weight === 'number' &&
+    !chipWeights.includes(weight);
+  if (weightIsDrift) {
+    chipWeights.push(weight as number);
+    chipWeights.sort((a, b) => a - b);
+  }
+
+  function stepWeight(direction: 1 | -1) {
+    if (useChipPicker) {
+      const opts = allowedWeights as number[];
+      const current = typeof weight === 'number' ? weight : suggestedWeight ?? opts[0];
+      const inList = opts.indexOf(current);
+      if (inList >= 0) {
+        const next = opts[Math.max(0, Math.min(opts.length - 1, inList + direction))];
+        setWeight(next);
+        return;
+      }
+      // Drift case: snap to nearest owned weight in the chosen direction.
+      if (direction === 1) {
+        const next = opts.find((w) => w > current);
+        setWeight(next ?? opts[opts.length - 1]);
+      } else {
+        const next = [...opts].reverse().find((w) => w < current);
+        setWeight(next ?? opts[0]);
+      }
+      return;
+    }
+    const current = weight ?? suggestedWeight ?? MIN_WEIGHT;
+    setWeight(current + direction * increment);
+  }
+
   return (
     <article
       class={
@@ -176,31 +221,74 @@ export function ExerciseCard({
         </div>
       )}
 
-      {exercise.usesWeight && (
-        <div class="mt-4 flex items-center gap-2">
+      {exercise.usesWeight && !inventoryEmptyForExercise && (
+        <div class="mt-4 flex flex-wrap items-center gap-2">
           <span class="text-[10px] font-medium uppercase tracking-[0.18em] text-flux-text-tertiary">
             Weight
           </span>
           <button
             type="button"
             class="flex h-8 w-8 items-center justify-center rounded-full bg-flux-soft text-base text-flux-text-secondary transition-colors hover:text-flux-text-primary"
-            onClick={() => setWeight((weight ?? suggestedWeight ?? MIN_WEIGHT) - increment)}
+            onClick={() => stepWeight(-1)}
             aria-label="Decrease weight"
           >
             −
           </button>
-          <input
-            type="number"
-            class="w-20 rounded-xl bg-flux-soft px-3 py-1.5 text-center text-sm font-medium tabular-nums text-flux-text-primary placeholder:text-flux-text-tertiary"
-            value={weight ?? ''}
-            placeholder={placeholder}
-            onInput={handleWeightInput}
-            data-testid={`weight-${index}`}
-          />
+          {useChipPicker ? (
+            <div
+              class="flex flex-1 flex-nowrap items-center gap-1.5 overflow-x-auto"
+              data-testid={`weight-chips-${index}`}
+            >
+              {chipWeights.map((w) => {
+                const selected = weight === w;
+                const drift = !allowedWeights!.includes(w);
+                return (
+                  <button
+                    key={w}
+                    type="button"
+                    aria-pressed={selected}
+                    onClick={() => setWeight(w)}
+                    data-testid={`weight-chip-${index}-${w}`}
+                    data-drift={drift ? 'true' : 'false'}
+                    title={drift ? 'Not in your inventory' : undefined}
+                    class={
+                      'shrink-0 rounded-full px-3 py-1 text-[11px] font-medium uppercase tracking-[0.15em] transition-colors ' +
+                      (selected
+                        ? drift
+                          ? 'border border-flux-border bg-transparent text-flux-text-primary'
+                          : 'bg-flux-accent text-flux-accent-fg shadow-flux-soft'
+                        : drift
+                          ? 'border border-flux-border bg-transparent text-flux-text-tertiary'
+                          : 'bg-flux-soft text-flux-text-secondary hover:text-flux-text-primary')
+                    }
+                  >
+                    {w}
+                    {drift && (
+                      <span
+                        class="ml-1 inline-block rounded-full bg-flux-soft px-1.5 py-0.5 text-[9px] tracking-[0.12em] text-flux-text-tertiary"
+                        data-testid={`weight-chip-drift-${index}-${w}`}
+                      >
+                        Unmapped
+                      </span>
+                    )}
+                  </button>
+                );
+              })}
+            </div>
+          ) : (
+            <input
+              type="number"
+              class="w-20 rounded-xl bg-flux-soft px-3 py-1.5 text-center text-sm font-medium tabular-nums text-flux-text-primary placeholder:text-flux-text-tertiary"
+              value={weight ?? ''}
+              placeholder={placeholder}
+              onInput={handleWeightInput}
+              data-testid={`weight-${index}`}
+            />
+          )}
           <button
             type="button"
             class="flex h-8 w-8 items-center justify-center rounded-full bg-flux-soft text-base text-flux-text-secondary transition-colors hover:text-flux-text-primary"
-            onClick={() => setWeight((weight ?? suggestedWeight ?? MIN_WEIGHT) + increment)}
+            onClick={() => stepWeight(1)}
             aria-label="Increase weight"
           >
             +

--- a/src/tabs/Workouts/components/ExerciseCard.tsx
+++ b/src/tabs/Workouts/components/ExerciseCard.tsx
@@ -281,7 +281,7 @@ export function ExerciseCard({
               class="w-20 rounded-xl bg-flux-soft px-3 py-1.5 text-center text-sm font-medium tabular-nums text-flux-text-primary placeholder:text-flux-text-tertiary"
               value={weight ?? ''}
               placeholder={placeholder}
-              onInput={handleWeightInput}
+              onChange={handleWeightInput}
               data-testid={`weight-${index}`}
             />
           )}

--- a/src/tabs/Workouts/index.tsx
+++ b/src/tabs/Workouts/index.tsx
@@ -9,12 +9,25 @@ import { resolveExercise } from './logic/resolveExercise';
 import {
   DEFAULT_STATE,
   deleteLogEntry,
+  loadLocations,
   loadLog,
   loadProgram,
   loadState,
   putLogEntry,
   saveState,
 } from './state';
+import {
+  activeInventory,
+  cloneDefaultLocationsState,
+  isInventoryConfigured,
+  type LocationsState,
+} from '../../data/inventory';
+import { EQUIPMENT_CATALOG, type EquipmentKind } from '../../data/equipmentCatalog';
+import {
+  allowedWeightsForExercise,
+  isExerciseSupportedByInventory,
+  missingKindsForExercise,
+} from './logic/equipmentResolve';
 import {
   applyProgramImportFromFile,
   formatProgramImportMessage,
@@ -26,6 +39,15 @@ import { VideoModal } from './components/VideoModal';
 function getCurrentPhase(program: Program | null, state: WorkoutState): Phase | null {
   if (!program) return null;
   return program.phases.find((p) => p.id === state.currentPhase) ?? null;
+}
+
+function formatDriftMessage(missing: EquipmentKind[]): string {
+  const names = missing.map((k) => EQUIPMENT_CATALOG[k]?.name.toLowerCase() ?? k);
+  let list: string;
+  if (names.length === 1) list = names[0];
+  else if (names.length === 2) list = `${names[0]} and ${names[1]}`;
+  else list = `${names.slice(0, -1).join(', ')}, and ${names[names.length - 1]}`;
+  return `Requires ${list} — not in your inventory.`;
 }
 
 interface VideoState {
@@ -43,13 +65,22 @@ export function Workouts() {
   // generation, persisted to the 'program' store in flux-db. No bundled
   // default — the empty state below covers a fresh install.
   const [program, setProgram] = useState<Program | null>(null);
+  const [locations, setLocations] = useState<LocationsState>(
+    cloneDefaultLocationsState,
+  );
 
   useEffect(() => {
     (async () => {
-      const [s, l, p] = await Promise.all([loadState(), loadLog(), loadProgram()]);
+      const [s, l, p, loc] = await Promise.all([
+        loadState(),
+        loadLog(),
+        loadProgram(),
+        loadLocations(),
+      ]);
       setState(s);
       setLog(l);
       setProgram(p);
+      setLocations(loc);
       setLoaded(true);
     })();
   }, []);
@@ -81,6 +112,12 @@ export function Workouts() {
   // Compute latest-weighted-entry-per-exercise once per log change so render
   // is O(M) instead of O(M*N) (scanning the full log for every exercise).
   const latestWeights = useMemo(() => buildLatestWeightedMap(log), [log]);
+
+  const inventory = useMemo(() => activeInventory(locations), [locations]);
+  const inventoryConfigured = useMemo(
+    () => isInventoryConfigured(locations),
+    [locations],
+  );
 
   const onLog = useCallback(
     (key: string, partial: Partial<LogEntry>, options?: { remove?: boolean }) => {
@@ -277,26 +314,49 @@ export function Workouts() {
             {resolvedExercises.map((ex, i) => {
               const key = `${state.globalDay}_${i}`;
               const last = latestWeights.get(ex.name) ?? null;
+              const hasEquipmentMeta = ex.equipmentRequired !== undefined;
+              const allowedWeights = hasEquipmentMeta
+                ? allowedWeightsForExercise(ex, inventory)
+                : null;
+              const supported = hasEquipmentMeta
+                ? isExerciseSupportedByInventory(ex, inventory)
+                : true;
+              const missing =
+                inventoryConfigured && !supported && hasEquipmentMeta
+                  ? missingKindsForExercise(ex, inventory)
+                  : [];
               const suggested = ex.usesWeight
                 ? suggestWeight(
                     last,
                     ex.startingWeight,
                     ex.weightIncrement ?? 5,
                     state.globalDay,
+                    allowedWeights,
                   )
                 : null;
               return (
-                <ExerciseCard
-                  key={key}
-                  exercise={ex}
-                  index={i}
-                  globalDay={state.globalDay}
-                  entry={log[key]}
-                  suggestedWeight={suggested}
-                  lastWeight={ex.usesWeight ? null : getLastWeight(last)}
-                  onLog={onLog}
-                  onPlayVideo={(videoId, start) => setVideo({ videoId, start })}
-                />
+                <div key={key} class="space-y-2">
+                  {inventoryConfigured && !supported && missing.length > 0 && (
+                    <div
+                      class="rounded-2xl bg-flux-soft px-3 py-2 text-[11px] uppercase tracking-[0.15em] text-flux-text-tertiary"
+                      data-testid={`inventory-drift-${i}`}
+                    >
+                      {formatDriftMessage(missing)}
+                    </div>
+                  )}
+                  <ExerciseCard
+                    exercise={ex}
+                    index={i}
+                    globalDay={state.globalDay}
+                    entry={log[key]}
+                    suggestedWeight={suggested}
+                    lastWeight={ex.usesWeight ? null : getLastWeight(last)}
+                    allowedWeights={allowedWeights}
+                    inventoryConfigured={inventoryConfigured}
+                    onLog={onLog}
+                    onPlayVideo={(videoId, start) => setVideo({ videoId, start })}
+                  />
+                </div>
               );
             })}
           </div>

--- a/src/tabs/Workouts/logic/equipmentResolve.ts
+++ b/src/tabs/Workouts/logic/equipmentResolve.ts
@@ -1,0 +1,99 @@
+// Glue between an exercise's equipment requirements (catalog metadata) and
+// the user's inventory (per-user state). The Workouts UI uses these helpers
+// to constrain weight pickers and surface drift banners.
+
+import { EQUIPMENT_CATALOG, type EquipmentKind } from '../../../data/equipmentCatalog';
+import type { Inventory } from '../../../data/inventory';
+
+// The helpers only need these fields from the catalog Exercise (or from a
+// ResolvedExercise that forwarded them). Decoupling keeps them callable
+// from the Workouts render without having to look the catalog up again.
+export interface EquipmentResolvable {
+  equipmentRequired?: EquipmentKind[];
+  equipmentAlternatives?: EquipmentKind[][];
+  usesWeight: boolean;
+}
+
+function isKindOwned(kind: EquipmentKind, inv: Inventory): boolean {
+  if (kind === 'bodyweight') return true;
+  return inv[kind] !== undefined;
+}
+
+function groupOwned(group: EquipmentKind[], inv: Inventory): boolean {
+  return group.every((k) => isKindOwned(k, inv));
+}
+
+// Returns the EquipmentKind list that the user actually satisfies for this
+// exercise: the primary requirement when fully owned, else the first
+// alternatives group that's fully owned, else null. Used internally by both
+// allowedWeightsForExercise and isExerciseSupportedByInventory.
+function resolveSatisfiedGroup(
+  ex: EquipmentResolvable,
+  inv: Inventory,
+): EquipmentKind[] | null {
+  const required = ex.equipmentRequired ?? [];
+  if (groupOwned(required, inv)) return required;
+  for (const alt of ex.equipmentAlternatives ?? []) {
+    if (groupOwned(alt, inv)) return alt;
+  }
+  return null;
+}
+
+// Returns the sorted-ascending list of weights the user can use for this
+// exercise's equipment.
+//   - null  → exercise doesn't use weight at all (no constraint)
+//   - []    → exercise needs weight but user owns no compatible equipment
+//   - [...] → owned weights, deduped, sorted ascending
+export function allowedWeightsForExercise(
+  ex: EquipmentResolvable,
+  inv: Inventory,
+): number[] | null {
+  if (!ex.usesWeight) return null;
+
+  const candidates: EquipmentKind[] = [];
+  const required = ex.equipmentRequired ?? [];
+  if (groupOwned(required, inv)) {
+    candidates.push(...required);
+  }
+  for (const alt of ex.equipmentAlternatives ?? []) {
+    if (groupOwned(alt, inv)) {
+      candidates.push(...alt);
+    }
+  }
+
+  if (candidates.length === 0) return [];
+
+  const set = new Set<number>();
+  for (const kind of candidates) {
+    if (kind === 'bodyweight') continue;
+    const meta = EQUIPMENT_CATALOG[kind];
+    if (!meta || !meta.hasWeightSelection) continue;
+    const item = inv[kind];
+    if (!item) continue;
+    for (const w of item.ownedWeights) {
+      if (Number.isFinite(w) && w > 0) set.add(w);
+    }
+  }
+  return Array.from(set).sort((a, b) => a - b);
+}
+
+// Returns true when the user owns enough equipment (any of equipmentRequired
+// OR any equipmentAlternatives group fully satisfied). 'bodyweight' is
+// always considered owned.
+export function isExerciseSupportedByInventory(
+  ex: EquipmentResolvable,
+  inv: Inventory,
+): boolean {
+  return resolveSatisfiedGroup(ex, inv) !== null;
+}
+
+// Returns the list of EquipmentKind values the user is missing relative to
+// the exercise's primary requirement. Used by the drift banner to phrase
+// "Requires kettlebell — not in your inventory."
+export function missingKindsForExercise(
+  ex: EquipmentResolvable,
+  inv: Inventory,
+): EquipmentKind[] {
+  const required = ex.equipmentRequired ?? [];
+  return required.filter((k) => !isKindOwned(k, inv));
+}

--- a/src/tabs/Workouts/logic/exportImport.ts
+++ b/src/tabs/Workouts/logic/exportImport.ts
@@ -6,14 +6,18 @@
 
 import { EXERCISE_CATALOG } from '../../../data/exerciseCatalog';
 import {
+  loadLocations,
   loadLog,
   loadProgram,
   loadState,
   putLogEntries,
+  saveLocations,
   saveProgram,
   saveState,
+  sanitizeLocationsState,
   sanitizeLogEntry,
 } from '../state';
+import { isInventoryConfigured } from '../../../data/inventory';
 import type {
   ExportPayload,
   LogEntry,
@@ -26,13 +30,15 @@ import type {
 } from '../types';
 
 export async function exportPayload(): Promise<ExportPayload> {
-  const [log, state, program] = await Promise.all([
+  const [log, state, program, locations] = await Promise.all([
     loadLog(),
     loadState(),
     loadProgram(),
+    loadLocations(),
   ]);
   const payload: ExportPayload = { log, state };
   if (program) payload.program = program;
+  if (isInventoryConfigured(locations)) payload.locations = locations;
   return payload;
 }
 
@@ -58,6 +64,7 @@ export interface ImportResult {
   total: number;
   stateApplied: boolean;
   programApplied: boolean;
+  inventoryApplied: boolean;
   // Populated when a program was imported. Reports how many of its exercises
   // resolved to a catalog entry by id, vs were kept by name as "unmapped".
   exerciseMapping?: {
@@ -72,24 +79,26 @@ export function formatImportMessage(result: ImportResult): string {
   const head =
     `Imported ${result.imported} of ${result.total} ${noun}` +
     (result.skipped ? ` (${result.skipped} skipped)` : '');
+  const inv = result.inventoryApplied ? ' Inventory restored.' : '';
   if (!result.programApplied) {
     // Backup imported but no program inside. Old-app exports don't carry a
     // program — point the user at the per-tab importer.
     if (result.imported > 0) {
       return (
-        `${head}. You still need to load a program — use "Import Program File" on the Workouts tab.`
+        `${head}. You still need to load a program — use "Import Program File" on the Workouts tab.${inv}`
       );
     }
-    return head;
+    return head + inv;
   }
   const m = result.exerciseMapping;
-  if (!m) return `${head}. Program loaded.`;
+  if (!m) return `${head}. Program loaded.${inv}`;
   if (m.unmapped === 0) {
-    return `${head}. Program loaded; ${m.mapped} of ${m.total} exercises map to the Flux catalog.`;
+    return `${head}. Program loaded; ${m.mapped} of ${m.total} exercises map to the Flux catalog.${inv}`;
   }
   return (
     `${head}. Imported. ${m.mapped} of ${m.total} exercises map to the Flux catalog.` +
-    " Unmapped will still log correctly but won't show demos."
+    " Unmapped will still log correctly but won't show demos." +
+    inv
   );
 }
 
@@ -339,12 +348,23 @@ export async function applyImport(
     }
   }
 
+  let inventoryApplied = false;
+  if (data.locations !== undefined) {
+    // Absence means "don't touch existing inventory"; presence means restore
+    // the sanitized payload. Unknown EquipmentKind keys and bad weights get
+    // dropped by sanitizeLocationsState.
+    const sanitized = sanitizeLocationsState(data.locations);
+    await saveLocations(sanitized);
+    inventoryApplied = true;
+  }
+
   return {
     imported,
     skipped,
     total: keys.length,
     stateApplied,
     programApplied,
+    inventoryApplied,
     ...(exerciseMapping ? { exerciseMapping } : {}),
   };
 }

--- a/src/tabs/Workouts/logic/progression.ts
+++ b/src/tabs/Workouts/logic/progression.ts
@@ -39,16 +39,31 @@ export function suggestWeight(
   startingWeight: number | undefined,
   increment: number,
   currentDay: number,
+  allowedWeights?: number[] | null,
 ): number {
+  let value: number;
   if (!last || !isValidWeight(last.weight)) {
-    return startingWeight ?? MIN_WEIGHT;
+    value = startingWeight ?? MIN_WEIGHT;
+  } else {
+    const lastWeek = weekFromDay(last.day);
+    const currentWeek = weekFromDay(currentDay);
+    value =
+      currentWeek > lastWeek
+        ? Math.min(last.weight + increment, MAX_WEIGHT)
+        : last.weight;
   }
-  const lastWeek = weekFromDay(last.day);
-  const currentWeek = weekFromDay(currentDay);
-  if (currentWeek > lastWeek) {
-    return Math.min(last.weight + increment, MAX_WEIGHT);
+  if (allowedWeights && allowedWeights.length > 0) {
+    // Snap DOWN to the highest owned weight ≤ value; if every owned weight is
+    // heavier, return the smallest one (don't suggest something the user
+    // doesn't own).
+    let best: number | null = null;
+    for (const w of allowedWeights) {
+      if (w <= value && (best === null || w > best)) best = w;
+    }
+    if (best !== null) return best;
+    return allowedWeights[0];
   }
-  return last.weight;
+  return value;
 }
 
 export function getLastWeight(last: LogEntry | null | undefined): number | null {

--- a/src/tabs/Workouts/logic/resolveExercise.ts
+++ b/src/tabs/Workouts/logic/resolveExercise.ts
@@ -21,6 +21,8 @@ export function resolveExercise(entry: WorkoutExercise): ResolvedExercise {
       usesWeight: cat.usesWeight,
       startingWeight: entry.starting_weight ?? cat.defaultStartingWeight,
       weightIncrement: entry.weight_increment ?? cat.defaultWeightIncrement,
+      equipmentRequired: cat.equipmentRequired,
+      equipmentAlternatives: cat.equipmentAlternatives,
     };
   }
   return {

--- a/src/tabs/Workouts/state.ts
+++ b/src/tabs/Workouts/state.ts
@@ -1,15 +1,25 @@
 import { openDb, dbGet, dbPut, dbPutMany, dbDelete, dbClear, dbGetAll } from '../../db/idb';
+import { EQUIPMENT_CATALOG, type EquipmentKind } from '../../data/equipmentCatalog';
+import {
+  cloneDefaultLocationsState,
+  type Inventory,
+  type InventoryItem,
+  type Location,
+  type LocationsState,
+} from '../../data/inventory';
 import type { LogEntry, LogMap, Program, WorkoutState } from './types';
 
 const DB_NAME = 'flux-db';
-// Bumped to 2 to add the 'program' store. New users get it on first open;
+// Bumped to 3 to add the 'inventory' store. New users get it on first open;
 // existing users get an automatic onupgradeneeded migration via openDb.
-const DB_VERSION = 2;
+const DB_VERSION = 3;
 const STATE_STORE = 'state';
 const LOG_STORE = 'log';
 const PROGRAM_STORE = 'program';
+const INVENTORY_STORE = 'inventory';
 const STATE_KEY = 'current';
 const PROGRAM_KEY = 'current';
+const INVENTORY_KEY = 'current';
 
 const DIFFICULTIES = new Set(['easy', 'good', 'hard', 'failed']);
 
@@ -24,6 +34,7 @@ export function getDb(): Promise<IDBDatabase> {
         { name: STATE_STORE },
         { name: LOG_STORE },
         { name: PROGRAM_STORE },
+        { name: INVENTORY_STORE },
       ],
     });
   }
@@ -95,6 +106,7 @@ export async function clearAll(): Promise<void> {
   await dbClear(db, STATE_STORE);
   await dbClear(db, LOG_STORE);
   await dbClear(db, PROGRAM_STORE);
+  await dbClear(db, INVENTORY_STORE);
 }
 
 export async function loadProgram(): Promise<Program | null> {
@@ -111,6 +123,18 @@ export async function saveProgram(program: Program): Promise<void> {
 export async function clearProgram(): Promise<void> {
   const db = await getDb();
   await dbDelete(db, PROGRAM_STORE, PROGRAM_KEY);
+}
+
+export async function loadLocations(): Promise<LocationsState> {
+  const db = await getDb();
+  const saved = await dbGet<unknown>(db, INVENTORY_STORE, INVENTORY_KEY);
+  if (!saved) return cloneDefaultLocationsState();
+  return sanitizeLocationsState(saved);
+}
+
+export async function saveLocations(state: LocationsState): Promise<void> {
+  const db = await getDb();
+  await dbPut(db, INVENTORY_STORE, state, INVENTORY_KEY);
 }
 
 // Returns the parsed list of all log entries in insertion order. Useful for
@@ -156,6 +180,81 @@ export function sanitizeLogEntry(raw: unknown): Partial<LogEntry> | null {
     out.failedRep = entry.failedRep;
   }
   return out;
+}
+
+function isObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+function sanitizeWeights(raw: unknown): number[] {
+  if (!Array.isArray(raw)) return [];
+  const seen = new Set<number>();
+  for (const v of raw) {
+    const n = typeof v === 'number' ? v : typeof v === 'string' ? parseFloat(v) : NaN;
+    if (Number.isFinite(n) && n > 0) seen.add(n);
+  }
+  return Array.from(seen).sort((a, b) => a - b);
+}
+
+export function sanitizeInventoryItem(
+  kind: EquipmentKind,
+  raw: unknown,
+): InventoryItem | null {
+  if (!isObject(raw)) return null;
+  const item: InventoryItem = {
+    kind,
+    ownedWeights: sanitizeWeights(raw.ownedWeights),
+  };
+  if (typeof raw.note === 'string' && raw.note.trim().length > 0) {
+    item.note = raw.note.slice(0, 200);
+  }
+  return item;
+}
+
+export function sanitizeInventory(raw: unknown): Inventory {
+  if (!isObject(raw)) return {};
+  const out: Inventory = {};
+  for (const [key, value] of Object.entries(raw)) {
+    if (!(key in EQUIPMENT_CATALOG)) continue;
+    const kind = key as EquipmentKind;
+    const item = sanitizeInventoryItem(kind, value);
+    if (item) out[kind] = item;
+  }
+  return out;
+}
+
+function sanitizeLocation(id: string, raw: unknown): Location | null {
+  if (!isObject(raw)) return null;
+  const name =
+    typeof raw.name === 'string' && raw.name.trim().length > 0
+      ? raw.name.slice(0, 80)
+      : id;
+  return {
+    id,
+    name,
+    inventory: sanitizeInventory(raw.inventory),
+  };
+}
+
+export function sanitizeLocationsState(raw: unknown): LocationsState {
+  if (!isObject(raw)) return cloneDefaultLocationsState();
+  const locationsRaw = isObject(raw.locations) ? raw.locations : null;
+  const locations: Record<string, Location> = {};
+  if (locationsRaw) {
+    for (const [id, value] of Object.entries(locationsRaw)) {
+      const loc = sanitizeLocation(id, value);
+      if (loc) locations[id] = loc;
+    }
+  }
+  if (Object.keys(locations).length === 0) {
+    locations.default = { id: 'default', name: 'Home', inventory: {} };
+  }
+  let activeId =
+    typeof raw.activeLocationId === 'string' ? raw.activeLocationId : '';
+  if (!locations[activeId]) {
+    activeId = locations.default ? 'default' : Object.keys(locations)[0];
+  }
+  return { locations, activeLocationId: activeId };
 }
 
 // Reset the cached connection — only used by tests that wipe the DB between runs.

--- a/src/tabs/Workouts/state.ts
+++ b/src/tabs/Workouts/state.ts
@@ -215,7 +215,7 @@ export function sanitizeInventory(raw: unknown): Inventory {
   if (!isObject(raw)) return {};
   const out: Inventory = {};
   for (const [key, value] of Object.entries(raw)) {
-    if (!(key in EQUIPMENT_CATALOG)) continue;
+    if (!Object.prototype.hasOwnProperty.call(EQUIPMENT_CATALOG, key)) continue;
     const kind = key as EquipmentKind;
     const item = sanitizeInventoryItem(kind, value);
     if (item) out[kind] = item;

--- a/src/tabs/Workouts/types.ts
+++ b/src/tabs/Workouts/types.ts
@@ -1,3 +1,6 @@
+import type { EquipmentKind } from '../../data/equipmentCatalog';
+import type { LocationsState } from '../../data/inventory';
+
 // Per-workout exercise prescription. References the exercise catalog by id;
 // metadata (name, demo video, technique notes) lives in src/data/exerciseCatalog.ts.
 export interface WorkoutExercise {
@@ -29,6 +32,10 @@ export interface ResolvedExercise {
   usesWeight: boolean;
   startingWeight?: number;
   weightIncrement?: number;
+  // Forwarded from the catalog so callers can run inventory checks without
+  // looking the entry up a second time.
+  equipmentRequired?: EquipmentKind[];
+  equipmentAlternatives?: EquipmentKind[][];
 }
 
 export interface Workout {
@@ -86,4 +93,5 @@ export interface ExportPayload {
   log: LogMap;
   state: Partial<WorkoutState>;
   program?: Program;
+  locations?: LocationsState;
 }

--- a/tests/inventory.spec.ts
+++ b/tests/inventory.spec.ts
@@ -1,0 +1,247 @@
+import { test, expect } from '@playwright/test';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { EXERCISE_CATALOG } from '../src/data/exerciseCatalog';
+import {
+  allowedWeightsForExercise,
+  isExerciseSupportedByInventory,
+} from '../src/tabs/Workouts/logic/equipmentResolve';
+import type { Inventory } from '../src/data/inventory';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PROGRAM_FIXTURE = join(__dirname, 'fixtures', 'test-program.json');
+
+async function resetAndSeedProgram(page: import('@playwright/test').Page) {
+  await page.goto('/');
+  await page.evaluate(async () => {
+    await new Promise<void>((resolve) => {
+      const req = indexedDB.deleteDatabase('flux-db');
+      req.onsuccess = () => resolve();
+      req.onerror = () => resolve();
+      req.onblocked = () => resolve();
+    });
+  });
+  await page.reload();
+  await page.getByTestId('import-program-btn').waitFor();
+  await page.locator('[data-tab="settings"]').click();
+  await page.getByTestId('import-input').setInputFiles(PROGRAM_FIXTURE);
+  await expect(page.getByTestId('backup-import-message')).toContainText('Imported');
+}
+
+async function configureKettlebellWeights(
+  page: import('@playwright/test').Page,
+  weights: number[],
+) {
+  await page.locator('[data-tab="settings"]').click();
+  await page.getByTestId('equipment-toggle-kettlebell').click();
+  for (const w of weights) {
+    await page.getByTestId('equipment-weight-input-kettlebell').fill(String(w));
+    await page.getByTestId('equipment-weight-add-kettlebell').click();
+  }
+}
+
+test.describe('inventory resolver unit tests', () => {
+  test('allowedWeightsForExercise returns null when exercise has no weight', () => {
+    const ex = EXERCISE_CATALOG['warmup-band-pull-aparts'];
+    expect(allowedWeightsForExercise(ex, {})).toBeNull();
+  });
+
+  test('allowedWeightsForExercise returns [] when required equipment is missing', () => {
+    const ex = EXERCISE_CATALOG['kettlebell-swings'];
+    expect(allowedWeightsForExercise(ex, {})).toEqual([]);
+  });
+
+  test('allowedWeightsForExercise returns owned weights sorted ascending and deduped', () => {
+    const ex = EXERCISE_CATALOG['kettlebell-swings'];
+    const inv: Inventory = {
+      kettlebell: { kind: 'kettlebell', ownedWeights: [35, 25, 25, 45] },
+    };
+    expect(allowedWeightsForExercise(ex, inv)).toEqual([25, 35, 45]);
+  });
+
+  test('allowedWeightsForExercise unions primary + alternative owned weights', () => {
+    // KB Gorilla Rows: required ['kettlebell'], alternatives [['dumbbell']].
+    const ex = EXERCISE_CATALOG['kb-gorilla-rows'];
+    const inv: Inventory = {
+      kettlebell: { kind: 'kettlebell', ownedWeights: [25, 35] },
+      dumbbell: { kind: 'dumbbell', ownedWeights: [30, 35] },
+    };
+    expect(allowedWeightsForExercise(ex, inv)).toEqual([25, 30, 35]);
+  });
+
+  test('isExerciseSupportedByInventory honors equipmentAlternatives', () => {
+    const ex = EXERCISE_CATALOG['kb-gorilla-rows'];
+    expect(isExerciseSupportedByInventory(ex, {})).toBe(false);
+    expect(
+      isExerciseSupportedByInventory(ex, {
+        dumbbell: { kind: 'dumbbell', ownedWeights: [30] },
+      }),
+    ).toBe(true);
+  });
+
+  test('isExerciseSupportedByInventory treats bodyweight as always owned', () => {
+    const ex = EXERCISE_CATALOG['90-90-hip-switch'];
+    expect(isExerciseSupportedByInventory(ex, {})).toBe(true);
+  });
+
+  test('allowedWeightsForExercise ignores hasWeightSelection=false equipment', () => {
+    // hanging-knee-raises requires pullup-bar (hasWeightSelection=false) but
+    // usesWeight=false anyway, so we get null. Force the test via swings.
+    const ex = EXERCISE_CATALOG['kettlebell-swings'];
+    const inv: Inventory = {
+      kettlebell: { kind: 'kettlebell', ownedWeights: [25] },
+      'pullup-bar': { kind: 'pullup-bar', ownedWeights: [] },
+    };
+    expect(allowedWeightsForExercise(ex, inv)).toEqual([25]);
+  });
+});
+
+test.describe('inventory e2e', () => {
+  test.beforeEach(async ({ context }) => {
+    await context.clearCookies();
+  });
+
+  test('first-run fallback: empty inventory keeps free-input picker', async ({
+    page,
+  }) => {
+    await resetAndSeedProgram(page);
+    await page.locator('[data-tab="workouts"]').click();
+    await expect(page.getByTestId('weight-3')).toBeVisible();
+    // No drift banner with empty inventory.
+    await expect(page.locator('[data-testid^="inventory-drift-"]')).toHaveCount(0);
+  });
+
+  test('configured inventory shows chip strip and constrains + / − stepping', async ({
+    page,
+  }) => {
+    await resetAndSeedProgram(page);
+    await configureKettlebellWeights(page, [25, 35, 45]);
+    await page.locator('[data-tab="workouts"]').click();
+
+    // Goblet squats is index 2 in workout A.
+    await expect(page.getByTestId('weight-chips-2')).toBeVisible();
+    await expect(page.getByTestId('weight-2')).toHaveCount(0);
+
+    // Chips appear for each owned weight.
+    await expect(page.getByTestId('weight-chip-2-25')).toBeVisible();
+    await expect(page.getByTestId('weight-chip-2-35')).toBeVisible();
+    await expect(page.getByTestId('weight-chip-2-45')).toBeVisible();
+
+    // Pick 25, then step up twice (25 → 35 → 45) and one more step stays at 45.
+    await page.getByTestId('weight-chip-2-25').click();
+    await expect(
+      page.getByTestId('weight-chip-2-25'),
+    ).toHaveAttribute('aria-pressed', 'true');
+
+    const inc = page.locator('[data-exercise-index="2"] button[aria-label="Increase weight"]');
+    await inc.click();
+    await expect(
+      page.getByTestId('weight-chip-2-35'),
+    ).toHaveAttribute('aria-pressed', 'true');
+    await inc.click();
+    await expect(
+      page.getByTestId('weight-chip-2-45'),
+    ).toHaveAttribute('aria-pressed', 'true');
+    await inc.click();
+    await expect(
+      page.getByTestId('weight-chip-2-45'),
+    ).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  test('drift: removing an owned weight still renders the logged value', async ({
+    page,
+  }) => {
+    await resetAndSeedProgram(page);
+    await configureKettlebellWeights(page, [25, 35, 45]);
+
+    // Log 25 on goblet squats.
+    await page.locator('[data-tab="workouts"]').click();
+    await page.getByTestId('weight-chip-2-25').click();
+
+    // Back to Settings, remove the 25 chip.
+    await page.locator('[data-tab="settings"]').click();
+    await page.getByTestId('equipment-chip-remove-kettlebell-25').click();
+
+    // Revisit Workouts — the 25 still renders for the drift entry.
+    await page.locator('[data-tab="workouts"]').click();
+    await expect(page.getByTestId('weight-chip-2-25')).toBeVisible();
+    await expect(page.getByTestId('weight-chip-2-25')).toHaveAttribute(
+      'data-drift',
+      'true',
+    );
+
+    // Other owned weights remain.
+    await expect(page.getByTestId('weight-chip-2-35')).toBeVisible();
+    await expect(page.getByTestId('weight-chip-2-45')).toBeVisible();
+  });
+
+  test('drift banner shows when required equipment is missing', async ({ page }) => {
+    await resetAndSeedProgram(page);
+
+    // Configure a non-relevant kind (so inventoryConfigured is true) but no kettlebell.
+    await page.locator('[data-tab="settings"]').click();
+    await page.getByTestId('equipment-toggle-dumbbell').click();
+    await page.getByTestId('equipment-weight-input-dumbbell').fill('30');
+    await page.getByTestId('equipment-weight-add-dumbbell').click();
+
+    // Now toggle dumbbell back off — but keep at least one kind configured.
+    // Actually we want kettlebell missing but inventory configured: dumbbell with 30 satisfies kb-gorilla-rows (alt)
+    // and goblet-squats (alt). So no drift banner expected for those.
+    // Force a real drift: kettlebell-swings only allows kettlebell.
+    await page.locator('[data-tab="workouts"]').click();
+
+    // kettlebell-swings is index 4 in workout A.
+    // Since we own dumbbell (30) but not kettlebell, and swings has no
+    // alternative, the drift banner should render.
+    await expect(page.getByTestId('inventory-drift-4')).toBeVisible();
+    await expect(page.getByTestId('inventory-drift-4')).toContainText(
+      'kettlebell',
+    );
+  });
+
+  test('export/import round-trips inventory', async ({ page }) => {
+    await resetAndSeedProgram(page);
+    await configureKettlebellWeights(page, [25, 35, 45]);
+
+    // Trigger export and capture file contents.
+    const downloadPromise = page.waitForEvent('download');
+    await page.getByTestId('export-btn').click();
+    const download = await downloadPromise;
+    const path = await download.path();
+    const contents = JSON.parse(readFileSync(path!, 'utf-8'));
+
+    expect(contents.locations).toBeDefined();
+    const inv =
+      contents.locations.locations[contents.locations.activeLocationId].inventory;
+    expect(inv.kettlebell.ownedWeights).toEqual([25, 35, 45]);
+
+    // Wipe DB, reload, import the exported payload, verify chips restored.
+    await page.evaluate(async () => {
+      await new Promise<void>((resolve) => {
+        const req = indexedDB.deleteDatabase('flux-db');
+        req.onsuccess = () => resolve();
+        req.onerror = () => resolve();
+        req.onblocked = () => resolve();
+      });
+    });
+    await page.reload();
+    await page.locator('[data-tab="settings"]').click();
+    await page
+      .getByTestId('import-input')
+      .setInputFiles({ name: 'export.json', mimeType: 'application/json', buffer: Buffer.from(JSON.stringify(contents)) });
+    await expect(page.getByTestId('backup-import-message')).toContainText(
+      'Inventory restored',
+    );
+
+    // Settings reflects restored weights.
+    await expect(page.getByTestId('equipment-chip-kettlebell-25')).toBeVisible();
+    await expect(page.getByTestId('equipment-chip-kettlebell-35')).toBeVisible();
+    await expect(page.getByTestId('equipment-chip-kettlebell-45')).toBeVisible();
+
+    // Workouts uses the chips again.
+    await page.locator('[data-tab="workouts"]').click();
+    await expect(page.getByTestId('weight-chips-2')).toBeVisible();
+  });
+});

--- a/tests/workouts.spec.ts
+++ b/tests/workouts.spec.ts
@@ -47,7 +47,10 @@ test('logs a set and persists it across reload', async ({ page }) => {
   await resetAndSeedProgram(page);
 
   // Day 1 workout A — exercise index 3 is the first weighted one (KB Gorilla Rows).
+  // Weight input uses onChange (fires on blur) to avoid per-keystroke writes,
+  // so commit the value with Tab before clicking Done.
   await page.getByTestId('weight-3').fill('30');
+  await page.getByTestId('weight-3').press('Tab');
   await page.getByTestId('done-3').click();
 
   await expect(page.getByTestId('done-3')).toContainText('Done');


### PR DESCRIPTION
## Summary

PR-B of three landing the equipment-inventory feature. PR-A added the app-level equipment catalog and exercise cross-reference; PR-C will integrate the AI program planner with the inventory.

This PR adds the user-facing storage, editor, and weight-picker constraints:

- **Per-user inventory store** wrapped in a `LocationsState` envelope (single 'Home' location now; multi-location is future-compat). Persisted in a new IDB `inventory` store; DB_VERSION bumped 2 → 3 (additive migration).
- **Settings → Equipment section** — toggle which kinds you own, edit per-kind weight chips with sensible presets (KB/DB/barbell), free-text note.
- **Constrained weight picker** on each `ExerciseCard`: when inventory is configured, the free-input is replaced with a horizontal chip strip over owned weights. `+ / −` step through owned weights only. Previously-logged weights that are no longer owned still render as drift chips (border-only) so historical data displays.
- **Drift banner** above each card when the user owns none of the required equipment (and no alternative group is satisfied). Weight controls drop entirely in that case.
- **`suggestWeight`** gains an optional `allowedWeights` param — snaps the suggestion DOWN to the highest owned weight ≤ the unconstrained value.
- **Export / import** round-trips inventory: present in the payload only when configured; sanitized on import (unknown EquipmentKind keys dropped, weights deduped/sorted); absence never wipes existing inventory.
- **First-run** users keep the existing free-input picker until they configure something — regression-safe for existing users.

## Test plan

- [x] Unit tests pass (`allowedWeightsForExercise`, `isExerciseSupportedByInventory` covering bodyweight sentinel + alternatives logic)
- [x] e2e tests pass
- [x] First-run users still see the free-input picker
- [x] Configured users see the chip picker
- [x] Drift banner appears when required equipment is removed
- [x] Drift chips render for historical log entries whose weight is no longer owned
- [x] Export / import round-trips inventory

Run: 20260529-1605-b2e31704