### PR TITLE
Wire LLM program generation to filtered catalog and inventory validation

### DIFF
--- a/prompts/generate-phase.md
+++ b/prompts/generate-phase.md
@@ -1,4 +1,60 @@
-# Core Principles (MUST be included in all phase prompts)
+# Flux — Phase / Program Generation Prompt
+
+This file is both:
+
+1. A **runtime template** the Flux app's program-generation orchestrator
+   substitutes and ships to an LLM (see `src/llm/programGen.ts`). The runtime
+   reads everything between the `RUNTIME PROMPT START` and `RUNTIME PROMPT END`
+   markers and substitutes `{{placeholders}}`.
+2. A **manual fallback** — copy/paste content the user can supply to an
+   external AI when no provider is configured in Flux Settings.
+
+The runtime template lives at the top so it is the first thing readers see;
+the manual fallback (which mirrors the historical phase prompts the user
+was pasting into Claude / Gemini / ChatGPT by hand) lives below the divider.
+
+> Until an LLM provider is configured in Settings, use the manual template
+> below — copy your equipment list, profile, and previous-phase data into
+> the prompt and paste into an external AI.
+
+---
+
+## RUNTIME PROMPT START
+
+{{user_request}}
+
+You are generating a workout program for Flux. Pick exercises ONLY from
+the filtered catalog below. Every exercise_id in your output must appear
+in this list. For exercises with allowed_weights, starting_weight MUST be
+a value from that list (or omitted entirely).
+
+## Filtered exercise catalog
+
+{{filtered_catalog_json}}
+
+## Previous program (for adaptation context)
+
+{{previous_program_or_none}}
+
+## Output schema
+
+Output a single valid JSON object: { meta, phases: [{ id, name, duration_weeks, description?, schedule_pattern?, workouts: { [key]: { name, focus, exercises: [{ exercise_id, sets, reps, rest, starting_weight?, weight_increment? }] } } }] }.
+
+meta.principles must include: injury_prevention, mobility_every_phase, form_over_load, longevity_focus. meta.constraints must include { mobility_required: true, min_mobility_days_per_week: 1 }.
+
+Output ONLY the JSON object, no commentary.
+
+## RUNTIME PROMPT END
+
+---
+
+# Manual fallback
+
+The remainder of this document is the manual paste-into-an-AI workflow that
+predates the runtime orchestrator. It stays here so users without a
+configured LLM provider can still drive program generation by hand.
+
+## Core Principles (MUST be included in all phase prompts)
 
 **CRITICAL: Include these constraints in every program generation request:**
 
@@ -30,24 +86,23 @@ MANDATORY REQUIREMENTS:
 
 ---
 
-# Phase 1: The Foundation (Months 1-3)
+## Phase 1: The Foundation (Months 1-3)
 "Act as a strength coach specializing in sarcopenia prevention and aesthetics for men over 45. Create a 12-week 'Recomposition' program for a male, 47, with mild back history.
 Equipment: Kettlebells, Swedish Ladder, Pull-up Bar, Peloton.
 Goal: Fix posture, build core stability, and establish neuromuscular connection.
 Format: Output valid JSON matching the 'Flux' schema.
 Schedule: 3 days Strength (Full Body), 2 days Conditioning (Peloton/Carries). Focus on tempo and form over heavy weight."
 
-# Phase 2: Hypertrophy & Shape (Months 4-7)
+## Phase 2: Hypertrophy & Shape (Months 4-7)
 "Update the program for the 'Hypertrophy' phase. The user has now added Adjustable Dumbbells (5-50lbs), a Bench, and TRX.
 Goal: Sarcoplasmic hypertrophy (muscle size) and 'V-taper' development (Back/Shoulders).
 Constraint: The user has mild ADD; vary the accessory movements every 4 weeks to maintain engagement.
 Format: JSON.
 Schedule: 4-day Upper/Lower split. Include supersets to increase density."
 
-# Phase 3: The "Reveal" & Cut (Months 8-12)
+## Phase 3: The "Reveal" & Cut (Months 8-12)
 "Update the program for the final 'Cutting' phase.
 Goal: Maximize caloric burn while maintaining muscle mass to get 'ripped' (10-12% body fat).
 Technique: Use 'Peripheral Heart Action' (alternating upper/lower exercises) to keep heart rate high.
 Format: JSON.
 Schedule: 3 days Full Body Metabolic Resistance Training + 2 days High-Intensity Intervals on Peloton."
-

--- a/src/llm/programGen.ts
+++ b/src/llm/programGen.ts
@@ -11,183 +11,25 @@
 // The provider stack is still stubbed in src/llm/index.ts — generateProgram
 // throws "LLM not configured" until the user configures a provider.
 
-import { EXERCISE_CATALOG } from '../data/exerciseCatalog';
-import type { Exercise } from '../data/types';
-import type { Inventory } from '../data/inventory';
-import {
-  allowedWeightsForExercise,
-  isExerciseSupportedByInventory,
-} from '../tabs/Workouts/logic/equipmentResolve';
-import type { EquipmentKind } from '../data/equipmentCatalog';
-import { validateProgramSchema, type Finding } from '../db/programSchema';
-import type { Program } from '../tabs/Workouts/types';
-import { generate } from './index';
-
 import promptTemplate from '../../prompts/generate-phase.md?raw';
+import {
+  generateProgramWithTemplate,
+  type GenerateProgramOptions,
+  type ProgramGenerationResult,
+} from './programGenCore';
 
-export interface FilteredExercise {
-  id: string;
-  name: string;
-  muscleGroups: string[];
-  equipmentRequired: EquipmentKind[];
-  // Resolved against inventory. null = bodyweight / no weight. [] never
-  // appears here because unsupported exercises are dropped upstream.
-  allowedWeights: number[] | null;
-  techniqueNote?: string;
-  demoVideoId?: string;
-}
+export {
+  buildFilteredCatalog,
+  extractRuntimeTemplate,
+  renderPrompt,
+  type FilteredCatalog,
+  type FilteredExercise,
+  type GenerateProgramOptions,
+  type ProgramGenerationResult,
+} from './programGenCore';
 
-export interface FilteredCatalog {
-  exercises: FilteredExercise[];
-  totalCatalogSize: number;
-  supportedCount: number;
-}
-
-export function buildFilteredCatalog(inv: Inventory): FilteredCatalog {
-  const entries = Object.values(EXERCISE_CATALOG);
-  const exercises: FilteredExercise[] = [];
-
-  for (const ex of entries) {
-    if (!isExerciseSupportedByInventory(ex, inv)) continue;
-    const allowedWeights = ex.usesWeight
-      ? allowedWeightsForExercise(ex, inv)
-      : null;
-    exercises.push(buildFilteredEntry(ex, allowedWeights));
-  }
-
-  return {
-    exercises,
-    totalCatalogSize: entries.length,
-    supportedCount: exercises.length,
-  };
-}
-
-function buildFilteredEntry(
-  ex: Exercise,
-  allowedWeights: number[] | null,
-): FilteredExercise {
-  const out: FilteredExercise = {
-    id: ex.id,
-    name: ex.name,
-    muscleGroups: ex.muscleGroups,
-    equipmentRequired: ex.equipmentRequired,
-    allowedWeights,
-  };
-  if (ex.techniqueNote !== undefined) out.techniqueNote = ex.techniqueNote;
-  if (ex.demoVideoId !== undefined) out.demoVideoId = ex.demoVideoId;
-  return out;
-}
-
-export interface ProgramGenerationResult {
-  program: Program;
-  warnings: Finding[];
-  filteredCatalog: FilteredCatalog;
-}
-
-export interface GenerateProgramOptions {
-  inventory: Inventory;
-  userRequest: string;
-  previousProgram?: Program;
-}
-
-// The schema reference embedded in the prompt. Mirrors the manual template
-// in prompts/generate-phase.md so coaches who want to inspect the exact
-// shape can do so without reading code.
-const PROGRAM_SCHEMA = {
-  type: 'object',
-  required: ['meta', 'phases'],
-  properties: {
-    meta: {
-      type: 'object',
-      required: ['startDate', 'version', 'principles', 'constraints'],
-    },
-    phases: { type: 'array' },
-  },
-};
-
-const RUNTIME_START_MARKER = '## RUNTIME PROMPT START';
-const RUNTIME_END_MARKER = '## RUNTIME PROMPT END';
-
-export function extractRuntimeTemplate(raw: string): string {
-  const start = raw.indexOf(RUNTIME_START_MARKER);
-  const end = raw.indexOf(RUNTIME_END_MARKER);
-  if (start === -1 || end === -1 || end <= start) {
-    throw new Error(
-      'prompts/generate-phase.md is missing RUNTIME PROMPT START/END markers',
-    );
-  }
-  return raw.slice(start + RUNTIME_START_MARKER.length, end).trim();
-}
-
-export function renderPrompt(opts: {
-  template: string;
-  userRequest: string;
-  filteredCatalog: FilteredCatalog;
-  previousProgram?: Program;
-}): string {
-  const catalogJson = JSON.stringify(
-    opts.filteredCatalog.exercises.map((e) => ({
-      id: e.id,
-      name: e.name,
-      muscle_groups: e.muscleGroups,
-      equipment_required: e.equipmentRequired,
-      allowed_weights: e.allowedWeights,
-      technique_note: e.techniqueNote,
-    })),
-    null,
-    2,
-  );
-  const prev = opts.previousProgram
-    ? JSON.stringify(opts.previousProgram, null, 2)
-    : 'none';
-  return opts.template
-    .replace('{{user_request}}', opts.userRequest.trim())
-    .replace('{{filtered_catalog_json}}', catalogJson)
-    .replace('{{previous_program_or_none}}', prev);
-}
-
-function stripCodeFences(s: string): string {
-  // Permissive: some providers wrap JSON in ```json ... ``` even when told not to.
-  const trimmed = s.trim();
-  const fence = /^```(?:json)?\s*([\s\S]*?)\s*```$/i;
-  const m = fence.exec(trimmed);
-  return m ? m[1].trim() : trimmed;
-}
-
-export async function generateProgram(
+export function generateProgram(
   opts: GenerateProgramOptions,
 ): Promise<ProgramGenerationResult> {
-  const filteredCatalog = buildFilteredCatalog(opts.inventory);
-  const template = extractRuntimeTemplate(promptTemplate);
-  const prompt = renderPrompt({
-    template,
-    userRequest: opts.userRequest,
-    filteredCatalog,
-    previousProgram: opts.previousProgram,
-  });
-
-  const raw = await generate({ prompt, schema: PROGRAM_SCHEMA });
-  if (typeof raw !== 'string') {
-    throw new Error('LLM provider returned a stream; generateProgram expects a single string response');
-  }
-
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(stripCodeFences(raw));
-  } catch (err) {
-    const message = err instanceof Error ? err.message : 'unknown parse error';
-    throw new Error(`AI returned non-JSON: ${message}`);
-  }
-
-  const result = validateProgramSchema(parsed, EXERCISE_CATALOG, opts.inventory);
-  if (result.errors.length > 0) {
-    const head = result.errors.slice(0, 3).map((f) => `${f.path}: ${f.message}`).join('; ');
-    throw new Error(`Generated program failed schema validation: ${head}`);
-  }
-
-  return {
-    program: parsed as Program,
-    warnings: result.warnings ?? [],
-    filteredCatalog,
-  };
+  return generateProgramWithTemplate(opts, promptTemplate);
 }

--- a/src/llm/programGen.ts
+++ b/src/llm/programGen.ts
@@ -1,0 +1,193 @@
+// Program-generation orchestrator. The single entry point feature code uses
+// to ask the LLM for a new workout phase.
+//
+// Pipeline:
+//   inventory + user request
+//     → buildFilteredCatalog (drop unsupported exercises, annotate weights)
+//     → render the runtime prompt template (prompts/generate-phase.md)
+//     → generate() via the active LLM provider
+//     → JSON.parse + validateProgram (errors throw, warnings flow back)
+//
+// The provider stack is still stubbed in src/llm/index.ts — generateProgram
+// throws "LLM not configured" until the user configures a provider.
+
+import { EXERCISE_CATALOG } from '../data/exerciseCatalog';
+import type { Exercise } from '../data/types';
+import type { Inventory } from '../data/inventory';
+import {
+  allowedWeightsForExercise,
+  isExerciseSupportedByInventory,
+} from '../tabs/Workouts/logic/equipmentResolve';
+import type { EquipmentKind } from '../data/equipmentCatalog';
+import { validateProgramSchema, type Finding } from '../db/programSchema';
+import type { Program } from '../tabs/Workouts/types';
+import { generate } from './index';
+
+import promptTemplate from '../../prompts/generate-phase.md?raw';
+
+export interface FilteredExercise {
+  id: string;
+  name: string;
+  muscleGroups: string[];
+  equipmentRequired: EquipmentKind[];
+  // Resolved against inventory. null = bodyweight / no weight. [] never
+  // appears here because unsupported exercises are dropped upstream.
+  allowedWeights: number[] | null;
+  techniqueNote?: string;
+  demoVideoId?: string;
+}
+
+export interface FilteredCatalog {
+  exercises: FilteredExercise[];
+  totalCatalogSize: number;
+  supportedCount: number;
+}
+
+export function buildFilteredCatalog(inv: Inventory): FilteredCatalog {
+  const entries = Object.values(EXERCISE_CATALOG);
+  const exercises: FilteredExercise[] = [];
+
+  for (const ex of entries) {
+    if (!isExerciseSupportedByInventory(ex, inv)) continue;
+    const allowedWeights = ex.usesWeight
+      ? allowedWeightsForExercise(ex, inv)
+      : null;
+    exercises.push(buildFilteredEntry(ex, allowedWeights));
+  }
+
+  return {
+    exercises,
+    totalCatalogSize: entries.length,
+    supportedCount: exercises.length,
+  };
+}
+
+function buildFilteredEntry(
+  ex: Exercise,
+  allowedWeights: number[] | null,
+): FilteredExercise {
+  const out: FilteredExercise = {
+    id: ex.id,
+    name: ex.name,
+    muscleGroups: ex.muscleGroups,
+    equipmentRequired: ex.equipmentRequired,
+    allowedWeights,
+  };
+  if (ex.techniqueNote !== undefined) out.techniqueNote = ex.techniqueNote;
+  if (ex.demoVideoId !== undefined) out.demoVideoId = ex.demoVideoId;
+  return out;
+}
+
+export interface ProgramGenerationResult {
+  program: Program;
+  warnings: Finding[];
+  filteredCatalog: FilteredCatalog;
+}
+
+export interface GenerateProgramOptions {
+  inventory: Inventory;
+  userRequest: string;
+  previousProgram?: Program;
+}
+
+// The schema reference embedded in the prompt. Mirrors the manual template
+// in prompts/generate-phase.md so coaches who want to inspect the exact
+// shape can do so without reading code.
+const PROGRAM_SCHEMA = {
+  type: 'object',
+  required: ['meta', 'phases'],
+  properties: {
+    meta: {
+      type: 'object',
+      required: ['startDate', 'version', 'principles', 'constraints'],
+    },
+    phases: { type: 'array' },
+  },
+};
+
+const RUNTIME_START_MARKER = '## RUNTIME PROMPT START';
+const RUNTIME_END_MARKER = '## RUNTIME PROMPT END';
+
+export function extractRuntimeTemplate(raw: string): string {
+  const start = raw.indexOf(RUNTIME_START_MARKER);
+  const end = raw.indexOf(RUNTIME_END_MARKER);
+  if (start === -1 || end === -1 || end <= start) {
+    throw new Error(
+      'prompts/generate-phase.md is missing RUNTIME PROMPT START/END markers',
+    );
+  }
+  return raw.slice(start + RUNTIME_START_MARKER.length, end).trim();
+}
+
+export function renderPrompt(opts: {
+  template: string;
+  userRequest: string;
+  filteredCatalog: FilteredCatalog;
+  previousProgram?: Program;
+}): string {
+  const catalogJson = JSON.stringify(
+    opts.filteredCatalog.exercises.map((e) => ({
+      id: e.id,
+      name: e.name,
+      muscle_groups: e.muscleGroups,
+      equipment_required: e.equipmentRequired,
+      allowed_weights: e.allowedWeights,
+      technique_note: e.techniqueNote,
+    })),
+    null,
+    2,
+  );
+  const prev = opts.previousProgram
+    ? JSON.stringify(opts.previousProgram, null, 2)
+    : 'none';
+  return opts.template
+    .replace('{{user_request}}', opts.userRequest.trim())
+    .replace('{{filtered_catalog_json}}', catalogJson)
+    .replace('{{previous_program_or_none}}', prev);
+}
+
+function stripCodeFences(s: string): string {
+  // Permissive: some providers wrap JSON in ```json ... ``` even when told not to.
+  const trimmed = s.trim();
+  const fence = /^```(?:json)?\s*([\s\S]*?)\s*```$/i;
+  const m = fence.exec(trimmed);
+  return m ? m[1].trim() : trimmed;
+}
+
+export async function generateProgram(
+  opts: GenerateProgramOptions,
+): Promise<ProgramGenerationResult> {
+  const filteredCatalog = buildFilteredCatalog(opts.inventory);
+  const template = extractRuntimeTemplate(promptTemplate);
+  const prompt = renderPrompt({
+    template,
+    userRequest: opts.userRequest,
+    filteredCatalog,
+    previousProgram: opts.previousProgram,
+  });
+
+  const raw = await generate({ prompt, schema: PROGRAM_SCHEMA });
+  if (typeof raw !== 'string') {
+    throw new Error('LLM provider returned a stream; generateProgram expects a single string response');
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stripCodeFences(raw));
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'unknown parse error';
+    throw new Error(`AI returned non-JSON: ${message}`);
+  }
+
+  const result = validateProgramSchema(parsed, EXERCISE_CATALOG, opts.inventory);
+  if (result.errors.length > 0) {
+    const head = result.errors.slice(0, 3).map((f) => `${f.path}: ${f.message}`).join('; ');
+    throw new Error(`Generated program failed schema validation: ${head}`);
+  }
+
+  return {
+    program: parsed as Program,
+    warnings: result.warnings ?? [],
+    filteredCatalog,
+  };
+}

--- a/src/llm/programGenCore.ts
+++ b/src/llm/programGenCore.ts
@@ -132,9 +132,9 @@ export function renderPrompt(opts: {
     ? JSON.stringify(opts.previousProgram, null, 2)
     : 'none';
   return opts.template
-    .replace('{{user_request}}', opts.userRequest.trim())
-    .replace('{{filtered_catalog_json}}', catalogJson)
-    .replace('{{previous_program_or_none}}', prev);
+    .replaceAll('{{user_request}}', opts.userRequest.trim())
+    .replaceAll('{{filtered_catalog_json}}', catalogJson)
+    .replaceAll('{{previous_program_or_none}}', prev);
 }
 
 function stripCodeFences(s: string): string {

--- a/src/llm/programGenCore.ts
+++ b/src/llm/programGenCore.ts
@@ -1,0 +1,193 @@
+// Pure helpers for program generation. Lives in its own file because the
+// outer programGen.ts uses Vite's `?raw` import to embed the prompt template
+// — that import isn't resolvable by node (tsx), so tests that need to drive
+// the orchestrator import the template via the filesystem and call into
+// generateProgramWithTemplate here directly.
+
+import { EXERCISE_CATALOG } from '../data/exerciseCatalog';
+import type { Exercise } from '../data/types';
+import type { Inventory } from '../data/inventory';
+import {
+  allowedWeightsForExercise,
+  isExerciseSupportedByInventory,
+} from '../tabs/Workouts/logic/equipmentResolve';
+import type { EquipmentKind } from '../data/equipmentCatalog';
+import { validateProgramSchema, type Finding } from '../db/programSchema';
+import type { Program } from '../tabs/Workouts/types';
+import { generate } from './index';
+
+export interface FilteredExercise {
+  id: string;
+  name: string;
+  muscleGroups: string[];
+  equipmentRequired: EquipmentKind[];
+  // Resolved against inventory. null = bodyweight / no weight. [] never
+  // appears here because unsupported exercises are dropped upstream.
+  allowedWeights: number[] | null;
+  techniqueNote?: string;
+  demoVideoId?: string;
+}
+
+export interface FilteredCatalog {
+  exercises: FilteredExercise[];
+  totalCatalogSize: number;
+  supportedCount: number;
+}
+
+export function buildFilteredCatalog(inv: Inventory): FilteredCatalog {
+  const entries = Object.values(EXERCISE_CATALOG);
+  const exercises: FilteredExercise[] = [];
+
+  for (const ex of entries) {
+    if (!isExerciseSupportedByInventory(ex, inv)) continue;
+    const allowedWeights = ex.usesWeight
+      ? allowedWeightsForExercise(ex, inv)
+      : null;
+    exercises.push(buildFilteredEntry(ex, allowedWeights));
+  }
+
+  return {
+    exercises,
+    totalCatalogSize: entries.length,
+    supportedCount: exercises.length,
+  };
+}
+
+function buildFilteredEntry(
+  ex: Exercise,
+  allowedWeights: number[] | null,
+): FilteredExercise {
+  const out: FilteredExercise = {
+    id: ex.id,
+    name: ex.name,
+    muscleGroups: ex.muscleGroups,
+    equipmentRequired: ex.equipmentRequired,
+    allowedWeights,
+  };
+  if (ex.techniqueNote !== undefined) out.techniqueNote = ex.techniqueNote;
+  if (ex.demoVideoId !== undefined) out.demoVideoId = ex.demoVideoId;
+  return out;
+}
+
+export interface ProgramGenerationResult {
+  program: Program;
+  warnings: Finding[];
+  filteredCatalog: FilteredCatalog;
+}
+
+export interface GenerateProgramOptions {
+  inventory: Inventory;
+  userRequest: string;
+  previousProgram?: Program;
+}
+
+// The schema reference embedded in the prompt. Mirrors the manual template
+// in prompts/generate-phase.md so coaches who want to inspect the exact
+// shape can do so without reading code.
+const PROGRAM_SCHEMA = {
+  type: 'object',
+  required: ['meta', 'phases'],
+  properties: {
+    meta: {
+      type: 'object',
+      required: ['startDate', 'version', 'principles', 'constraints'],
+    },
+    phases: { type: 'array' },
+  },
+};
+
+const RUNTIME_START_MARKER = '## RUNTIME PROMPT START';
+const RUNTIME_END_MARKER = '## RUNTIME PROMPT END';
+
+export function extractRuntimeTemplate(raw: string): string {
+  const start = raw.indexOf(RUNTIME_START_MARKER);
+  const end = raw.indexOf(RUNTIME_END_MARKER);
+  if (start === -1 || end === -1 || end <= start) {
+    throw new Error(
+      'prompts/generate-phase.md is missing RUNTIME PROMPT START/END markers',
+    );
+  }
+  return raw.slice(start + RUNTIME_START_MARKER.length, end).trim();
+}
+
+export function renderPrompt(opts: {
+  template: string;
+  userRequest: string;
+  filteredCatalog: FilteredCatalog;
+  previousProgram?: Program;
+}): string {
+  const catalogJson = JSON.stringify(
+    opts.filteredCatalog.exercises.map((e) => ({
+      id: e.id,
+      name: e.name,
+      muscle_groups: e.muscleGroups,
+      equipment_required: e.equipmentRequired,
+      allowed_weights: e.allowedWeights,
+      technique_note: e.techniqueNote,
+    })),
+    null,
+    2,
+  );
+  const prev = opts.previousProgram
+    ? JSON.stringify(opts.previousProgram, null, 2)
+    : 'none';
+  return opts.template
+    .replace('{{user_request}}', opts.userRequest.trim())
+    .replace('{{filtered_catalog_json}}', catalogJson)
+    .replace('{{previous_program_or_none}}', prev);
+}
+
+function stripCodeFences(s: string): string {
+  // Permissive: some providers wrap JSON in ```json ... ``` even when told not to.
+  const trimmed = s.trim();
+  const fence = /^```(?:json)?\s*([\s\S]*?)\s*```$/i;
+  const m = fence.exec(trimmed);
+  return m ? m[1].trim() : trimmed;
+}
+
+// Orchestrator implementation parameterized by the prompt template so it
+// can be exercised from a node test without going through Vite's ?raw
+// import. The exported generateProgram() in programGen.ts is a thin wrapper.
+export async function generateProgramWithTemplate(
+  opts: GenerateProgramOptions,
+  promptTemplate: string,
+): Promise<ProgramGenerationResult> {
+  const filteredCatalog = buildFilteredCatalog(opts.inventory);
+  const template = extractRuntimeTemplate(promptTemplate);
+  const prompt = renderPrompt({
+    template,
+    userRequest: opts.userRequest,
+    filteredCatalog,
+    previousProgram: opts.previousProgram,
+  });
+
+  const raw = await generate({ prompt, schema: PROGRAM_SCHEMA });
+  if (typeof raw !== 'string') {
+    throw new Error(
+      'LLM provider returned a stream; generateProgram expects a single string response',
+    );
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stripCodeFences(raw));
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'unknown parse error';
+    throw new Error(`AI returned non-JSON: ${message}`);
+  }
+
+  const result = validateProgramSchema(parsed, EXERCISE_CATALOG, opts.inventory);
+  if (result.errors.length > 0) {
+    const head = result.errors
+      .slice(0, 3)
+      .map((f) => `${f.path}: ${f.message}`)
+      .join('; ');
+    throw new Error(`Generated program failed schema validation: ${head}`);
+  }
+
+  return {
+    program: parsed as Program,
+    warnings: result.warnings ?? [],
+    filteredCatalog,
+  };
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,7 @@
 import { render } from 'preact';
 import { App } from './App';
 import type { EntryTab } from './App';
+import { configureProvider, type LLMProvider } from './llm';
 import './index.css';
 
 interface AppEntryBridge {
@@ -11,6 +12,10 @@ declare global {
   interface Window {
     __entry?: EntryTab;
     AppEntry?: AppEntryBridge;
+    // Test hook: Playwright e2e tests stub an LLM provider through this so
+    // the program-generation flow can be exercised without a real backend.
+    // Not used by app code. Stable string so tests can rely on the name.
+    flux_test_configureLLM?: (provider: LLMProvider) => void;
   }
 }
 
@@ -37,6 +42,12 @@ function resolveEntry(): EntryTab {
 const root = document.getElementById('app');
 if (!root) {
   throw new Error('#app root element missing');
+}
+
+if (typeof window !== 'undefined') {
+  window.flux_test_configureLLM = (provider: LLMProvider) => {
+    configureProvider(provider);
+  };
 }
 
 render(<App entry={resolveEntry()} />, root);

--- a/src/tabs/Workouts/components/GenerateAIModal.tsx
+++ b/src/tabs/Workouts/components/GenerateAIModal.tsx
@@ -102,7 +102,7 @@ export function GenerateAIModal({
               phase.
             </p>
             <textarea
-              class="h-40 w-full resize-y rounded-2xl bg-flux-soft px-3 py-2 text-sm text-flux-text-primary placeholder:text-flux-text-tertiary focus:outline-none"
+              class="h-40 w-full resize-y rounded-2xl bg-flux-soft px-3 py-2 text-sm text-flux-text-primary placeholder:text-flux-text-tertiary"
               placeholder={PLACEHOLDER}
               value={request}
               onInput={(e) => setRequest((e.target as HTMLTextAreaElement).value)}

--- a/src/tabs/Workouts/components/GenerateAIModal.tsx
+++ b/src/tabs/Workouts/components/GenerateAIModal.tsx
@@ -1,0 +1,213 @@
+import { useEffect, useState } from 'preact/hooks';
+import { generateProgram } from '../../../llm/programGen';
+import type { ProgramGenerationResult } from '../../../llm/programGen';
+import type { Inventory } from '../../../data/inventory';
+import type { Program } from '../types';
+
+interface Props {
+  inventory: Inventory;
+  previousProgram?: Program | null;
+  onClose: () => void;
+  onSaved: (program: Program) => void;
+}
+
+type Phase = 'request' | 'generating' | 'review' | 'error';
+
+const PLACEHOLDER = `e.g. "12-week recomposition phase for someone returning from a lower-back tweak. Three strength days and two mobility days a week. Build on Phase 1 — focus on hinge mechanics and posterior chain."`;
+
+export function GenerateAIModal({
+  inventory,
+  previousProgram,
+  onClose,
+  onSaved,
+}: Props) {
+  const [phase, setPhase] = useState<Phase>('request');
+  const [request, setRequest] = useState('');
+  const [result, setResult] = useState<ProgramGenerationResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
+  async function handleSubmit() {
+    setPhase('generating');
+    setError(null);
+    try {
+      const r = await generateProgram({
+        inventory,
+        userRequest: request,
+        previousProgram: previousProgram ?? undefined,
+      });
+      setResult(r);
+      setPhase('review');
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Generation failed';
+      setError(msg);
+      setPhase('error');
+    }
+  }
+
+  function handleSave() {
+    if (result) onSaved(result.program);
+  }
+
+  const program = result?.program;
+  const phaseCount = program?.phases.length ?? 0;
+  const exerciseCount =
+    program?.phases.reduce(
+      (sum, p) =>
+        sum +
+        Object.values(p.workouts).reduce(
+          (s, w) => s + w.exercises.length,
+          0,
+        ),
+      0,
+    ) ?? 0;
+
+  return (
+    <div
+      class="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4"
+      onClick={onClose}
+      data-testid="generate-ai-modal"
+    >
+      <div
+        class="w-full max-w-md rounded-[2rem] bg-flux-card p-6 shadow-flux-card"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div class="flex items-center justify-between">
+          <p class="text-[10px] font-medium uppercase tracking-[0.2em] text-flux-text-tertiary">
+            Generate program
+          </p>
+          <button
+            type="button"
+            class="text-flux-text-tertiary hover:text-flux-text-primary"
+            onClick={onClose}
+            aria-label="Close"
+            data-testid="generate-ai-close"
+          >
+            ×
+          </button>
+        </div>
+
+        {phase === 'request' && (
+          <div class="mt-4 space-y-4">
+            <p class="text-sm text-flux-text-secondary">
+              Describe the phase you want. Include goals, duration, schedule
+              preferences, and anything the coach should know about your prior
+              phase.
+            </p>
+            <textarea
+              class="h-40 w-full resize-y rounded-2xl bg-flux-soft px-3 py-2 text-sm text-flux-text-primary placeholder:text-flux-text-tertiary focus:outline-none"
+              placeholder={PLACEHOLDER}
+              value={request}
+              onInput={(e) => setRequest((e.target as HTMLTextAreaElement).value)}
+              data-testid="generate-ai-request"
+            />
+            <button
+              type="button"
+              class="w-full rounded-full bg-flux-accent px-5 py-2.5 text-[11px] font-medium uppercase tracking-[0.15em] text-flux-accent-fg shadow-flux-soft transition-opacity hover:opacity-90 disabled:opacity-40"
+              onClick={handleSubmit}
+              disabled={request.trim().length === 0}
+              data-testid="generate-ai-submit"
+            >
+              Generate
+            </button>
+          </div>
+        )}
+
+        {phase === 'generating' && (
+          <div class="mt-6 space-y-2 text-center">
+            <p
+              class="text-sm text-flux-text-secondary"
+              data-testid="generate-ai-loading"
+            >
+              Generating program…
+            </p>
+            <p class="text-[10px] uppercase tracking-[0.2em] text-flux-text-tertiary">
+              This can take 20–60 seconds
+            </p>
+          </div>
+        )}
+
+        {phase === 'review' && program && (
+          <div class="mt-4 space-y-4" data-testid="generate-ai-review">
+            <div class="flex items-baseline gap-3 text-[10px] uppercase tracking-[0.2em] text-flux-text-tertiary">
+              <span>
+                Phases <span class="text-flux-text-primary">{phaseCount}</span>
+              </span>
+              <span aria-hidden="true">·</span>
+              <span>
+                Exercises{' '}
+                <span class="text-flux-text-primary">{exerciseCount}</span>
+              </span>
+            </div>
+            {result && result.warnings.length > 0 && (
+              <div class="space-y-1">
+                <p class="text-[10px] uppercase tracking-[0.2em] text-flux-text-tertiary">
+                  Inventory warnings
+                </p>
+                <ul class="space-y-1 text-xs text-flux-text-secondary">
+                  {result.warnings.map((w, i) => (
+                    <li
+                      key={i}
+                      class="rounded-2xl bg-flux-soft px-3 py-2"
+                      data-testid={`generate-ai-warning-${i}`}
+                    >
+                      {friendlyWarning(w.message)}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+            <div class="flex gap-2">
+              <button
+                type="button"
+                class="flex-1 rounded-full bg-flux-card px-5 py-2.5 text-[11px] font-medium uppercase tracking-[0.15em] text-flux-text-secondary shadow-flux-soft hover:text-flux-text-primary"
+                onClick={onClose}
+                data-testid="generate-ai-discard"
+              >
+                Discard
+              </button>
+              <button
+                type="button"
+                class="flex-1 rounded-full bg-flux-accent px-5 py-2.5 text-[11px] font-medium uppercase tracking-[0.15em] text-flux-accent-fg shadow-flux-soft hover:opacity-90"
+                onClick={handleSave}
+                data-testid="generate-ai-save"
+              >
+                Save program
+              </button>
+            </div>
+          </div>
+        )}
+
+        {phase === 'error' && (
+          <div class="mt-4 space-y-3" data-testid="generate-ai-error">
+            <p class="text-sm text-flux-text-secondary">
+              {error ?? 'Generation failed.'}
+            </p>
+            <button
+              type="button"
+              class="w-full rounded-full bg-flux-accent px-5 py-2.5 text-[11px] font-medium uppercase tracking-[0.15em] text-flux-accent-fg shadow-flux-soft hover:opacity-90"
+              onClick={() => setPhase('request')}
+              data-testid="generate-ai-retry"
+            >
+              Try again
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function friendlyWarning(raw: string): string {
+  // validateProgramSchema yields messages like "requires kettlebell; not in inventory".
+  const m = /requires (.+); not in inventory/.exec(raw);
+  if (m) return `An exercise requires ${m[1]} — not in your inventory.`;
+  return raw;
+}

--- a/src/tabs/Workouts/index.tsx
+++ b/src/tabs/Workouts/index.tsx
@@ -446,8 +446,9 @@ export function Workouts() {
             setAiOpen(false);
             try {
               await saveProgram(p);
-            } catch {
-              // Surfaces nothing for now — the program is in memory either way.
+            } catch (err) {
+              const msg = err instanceof Error ? err.message : String(err);
+              setImportMessage(`Failed to save program: ${msg}`);
             }
           }}
         />

--- a/src/tabs/Workouts/index.tsx
+++ b/src/tabs/Workouts/index.tsx
@@ -14,8 +14,11 @@ import {
   loadProgram,
   loadState,
   putLogEntry,
+  saveProgram,
   saveState,
 } from './state';
+import { useLLM } from '../../llm';
+import { GenerateAIModal } from './components/GenerateAIModal';
 import {
   activeInventory,
   cloneDefaultLocationsState,
@@ -68,6 +71,8 @@ export function Workouts() {
   const [locations, setLocations] = useState<LocationsState>(
     cloneDefaultLocationsState,
   );
+  const [aiOpen, setAiOpen] = useState(false);
+  const llm = useLLM();
 
   useEffect(() => {
     (async () => {
@@ -265,12 +270,21 @@ export function Workouts() {
             </button>
             <button
               type="button"
-              class="cursor-not-allowed rounded-full bg-flux-soft px-5 py-2.5 text-[11px] font-medium uppercase tracking-[0.15em] text-flux-text-tertiary"
-              disabled
+              class={
+                llm.available
+                  ? 'rounded-full bg-flux-accent px-5 py-2.5 text-[11px] font-medium uppercase tracking-[0.15em] text-flux-accent-fg shadow-flux-soft transition-opacity hover:opacity-90'
+                  : 'cursor-not-allowed rounded-full bg-flux-soft px-5 py-2.5 text-[11px] font-medium uppercase tracking-[0.15em] text-flux-text-tertiary'
+              }
+              disabled={!llm.available}
+              onClick={() => setAiOpen(true)}
               data-testid="generate-ai-btn"
-              title="AI program generation is on the roadmap."
+              title={
+                llm.available
+                  ? 'Generate a program with the configured LLM.'
+                  : 'Configure an LLM provider in Settings to enable.'
+              }
             >
-              Generate with AI (soon)
+              {llm.available ? 'Generate with AI' : 'Generate with AI (configure in Settings)'}
             </button>
           </div>
           <input
@@ -419,6 +433,23 @@ export function Workouts() {
           videoId={video.videoId}
           start={video.start}
           onClose={() => setVideo(null)}
+        />
+      )}
+
+      {aiOpen && (
+        <GenerateAIModal
+          inventory={inventory}
+          previousProgram={program}
+          onClose={() => setAiOpen(false)}
+          onSaved={async (p) => {
+            setProgram(p);
+            setAiOpen(false);
+            try {
+              await saveProgram(p);
+            } catch {
+              // Surfaces nothing for now — the program is in memory either way.
+            }
+          }}
         />
       )}
     </section>

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="vite/client" />
+
+declare module '*?raw' {
+  const content: string;
+  export default content;
+}

--- a/tests/generate-ai-ui.spec.ts
+++ b/tests/generate-ai-ui.spec.ts
@@ -1,0 +1,209 @@
+import { test, expect } from '@playwright/test';
+
+// Helpers ---------------------------------------------------------------------
+
+async function freshApp(page: import('@playwright/test').Page) {
+  await page.goto('/');
+  await page.evaluate(async () => {
+    await new Promise<void>((resolve) => {
+      const req = indexedDB.deleteDatabase('flux-db');
+      req.onsuccess = () => resolve();
+      req.onerror = () => resolve();
+      req.onblocked = () => resolve();
+    });
+  });
+  await page.reload();
+  await page.locator('[data-tab="workouts"]').click();
+  await page.getByTestId('no-program').waitFor();
+}
+
+// A program that uses only catalog ids (we use bodyweight ones so the
+// empty inventory we ship with passes validation cleanly).
+const FAKE_PROGRAM = {
+  meta: {
+    startDate: '2026-06-01',
+    version: 'ui-fake-1',
+    principles: [
+      'injury_prevention',
+      'mobility_every_phase',
+      'form_over_load',
+      'longevity_focus',
+    ],
+    constraints: { mobility_required: true, min_mobility_days_per_week: 1 },
+  },
+  phases: [
+    {
+      id: 'p1',
+      name: 'Generated Phase',
+      duration_weeks: 4,
+      schedule_pattern: ['Mobility', 'Mobility', 'Mobility', 'Mobility', 'Mobility', 'Mobility', 'Rest'],
+      workouts: {
+        Mobility: {
+          name: 'Mobility & Flow',
+          focus: 'mobility',
+          exercises: [
+            {
+              exercise_id: 'cat-cow-spinal-flow',
+              sets: 2,
+              reps: '10',
+              rest: '30s',
+            },
+            {
+              exercise_id: 'thread-the-needle',
+              sets: 2,
+              reps: '8 each side',
+              rest: '30s',
+            },
+          ],
+        },
+      },
+    },
+  ],
+};
+
+async function installFakeProvider(
+  page: import('@playwright/test').Page,
+  responseJson: unknown,
+) {
+  await page.evaluate((payload) => {
+    const fn = (window as unknown as {
+      flux_test_configureLLM?: (p: {
+        id: string;
+        available: boolean;
+        generate: (opts: unknown) => Promise<string>;
+      }) => void;
+    }).flux_test_configureLLM;
+    if (!fn) throw new Error('flux_test_configureLLM not exposed');
+    fn({
+      id: 'fake-ui',
+      available: true,
+      async generate() {
+        return JSON.stringify(payload);
+      },
+    });
+  }, responseJson);
+}
+
+// Tests -----------------------------------------------------------------------
+
+test.beforeEach(async ({ context }) => {
+  await context.clearCookies();
+});
+
+test('with no LLM available, generate button is disabled and tooltip points to Settings', async ({
+  page,
+}) => {
+  await freshApp(page);
+  const btn = page.getByTestId('generate-ai-btn');
+  await expect(btn).toBeVisible();
+  await expect(btn).toBeDisabled();
+  await expect(btn).toHaveAttribute(
+    'title',
+    /Configure an LLM provider in Settings/i,
+  );
+});
+
+test('with a mocked provider, generate flow opens modal, generates, reviews, and saves', async ({
+  page,
+}) => {
+  await freshApp(page);
+  await installFakeProvider(page, FAKE_PROGRAM);
+
+  const btn = page.getByTestId('generate-ai-btn');
+  await expect(btn).toBeEnabled();
+  await btn.click();
+
+  await expect(page.getByTestId('generate-ai-modal')).toBeVisible();
+  await page.getByTestId('generate-ai-request').fill('Mobility-only phase');
+
+  await page.getByTestId('generate-ai-submit').click();
+  await expect(page.getByTestId('generate-ai-review')).toBeVisible();
+
+  // No warnings expected — the program uses bodyweight exercises only.
+  await expect(
+    page.locator('[data-testid^="generate-ai-warning-"]'),
+  ).toHaveCount(0);
+
+  await page.getByTestId('generate-ai-save').click();
+
+  // Workouts tab transitions to the loaded-program state.
+  await expect(page.getByTestId('no-program')).toHaveCount(0);
+  await expect(page.getByTestId('workout-name')).toContainText('Mobility & Flow');
+  await expect(page.getByTestId('phase-name')).toContainText('Generated Phase');
+});
+
+test('warnings render on the review screen when the program references unsupported equipment', async ({
+  page,
+}) => {
+  await freshApp(page);
+
+  // Program references kettlebell-swings but the user has no kettlebell.
+  const driftProgram = {
+    ...FAKE_PROGRAM,
+    phases: [
+      {
+        ...FAKE_PROGRAM.phases[0],
+        workouts: {
+          ...FAKE_PROGRAM.phases[0].workouts,
+          Strength: {
+            name: 'Strength A',
+            focus: 'lower',
+            exercises: [
+              {
+                exercise_id: 'kettlebell-swings',
+                sets: 3,
+                reps: '15',
+                rest: '60s',
+              },
+            ],
+          },
+        },
+      },
+    ],
+  };
+
+  await installFakeProvider(page, driftProgram);
+
+  await page.getByTestId('generate-ai-btn').click();
+  await page.getByTestId('generate-ai-request').fill('A phase, please');
+  await page.getByTestId('generate-ai-submit').click();
+
+  await expect(page.getByTestId('generate-ai-review')).toBeVisible();
+  await expect(page.getByTestId('generate-ai-warning-0')).toBeVisible();
+  await expect(page.getByTestId('generate-ai-warning-0')).toContainText(
+    /kettlebell/i,
+  );
+});
+
+test('non-JSON provider response shows the error screen with a retry option', async ({
+  page,
+}) => {
+  await freshApp(page);
+  await page.evaluate(() => {
+    const fn = (window as unknown as {
+      flux_test_configureLLM?: (p: {
+        id: string;
+        available: boolean;
+        generate: (opts: unknown) => Promise<string>;
+      }) => void;
+    }).flux_test_configureLLM;
+    if (!fn) throw new Error('flux_test_configureLLM not exposed');
+    fn({
+      id: 'fake-bad',
+      available: true,
+      async generate() {
+        return 'not json';
+      },
+    });
+  });
+
+  await page.getByTestId('generate-ai-btn').click();
+  await page.getByTestId('generate-ai-request').fill('anything');
+  await page.getByTestId('generate-ai-submit').click();
+
+  await expect(page.getByTestId('generate-ai-error')).toBeVisible();
+  await expect(page.getByTestId('generate-ai-error')).toContainText(
+    /non-JSON/i,
+  );
+  await expect(page.getByTestId('generate-ai-retry')).toBeVisible();
+});

--- a/tests/programGen.spec.ts
+++ b/tests/programGen.spec.ts
@@ -1,0 +1,313 @@
+import { test, expect } from '@playwright/test';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+import { EXERCISE_CATALOG } from '../src/data/exerciseCatalog';
+import {
+  buildFilteredCatalog,
+  extractRuntimeTemplate,
+  generateProgramWithTemplate,
+  renderPrompt,
+} from '../src/llm/programGenCore';
+import { configureProvider, type LLMProvider } from '../src/llm';
+import type { Inventory } from '../src/data/inventory';
+import type { Program } from '../src/tabs/Workouts/types';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PROMPT_PATH = resolve(__dirname, '..', 'prompts', 'generate-phase.md');
+const RAW_TEMPLATE = readFileSync(PROMPT_PATH, 'utf8');
+
+function idsOf(catalog: ReturnType<typeof buildFilteredCatalog>): string[] {
+  return catalog.exercises.map((e) => e.id).sort();
+}
+
+function validProgram(exerciseId: string): Program {
+  return {
+    meta: {
+      startDate: '2026-06-01',
+      version: 'gen-1',
+      principles: [
+        'injury_prevention',
+        'mobility_every_phase',
+        'form_over_load',
+        'longevity_focus',
+      ],
+      constraints: { mobility_required: true, min_mobility_days_per_week: 1 },
+    },
+    phases: [
+      {
+        id: 'p1',
+        name: 'Generated Phase',
+        duration_weeks: 4,
+        workouts: {
+          A: {
+            name: 'Workout A',
+            focus: 'mixed',
+            exercises: [
+              {
+                exercise_id: exerciseId,
+                sets: 3,
+                reps: '8-12',
+                rest: '90s',
+              },
+            ],
+          },
+          Mobility: {
+            name: 'Mobility & Flow',
+            focus: 'mobility',
+            exercises: [
+              {
+                exercise_id: 'cat-cow-spinal-flow',
+                sets: 2,
+                reps: '10',
+                rest: '30s',
+              },
+            ],
+          },
+        },
+      },
+    ],
+  };
+}
+
+function fakeProvider(
+  generator: (prompt: string) => string | Promise<string>,
+): {
+  provider: LLMProvider;
+  lastPrompt: () => string;
+} {
+  let lastPrompt = '';
+  const provider: LLMProvider = {
+    id: 'fake',
+    available: true,
+    async generate(opts) {
+      lastPrompt = opts.prompt;
+      const out = await generator(opts.prompt);
+      return out;
+    },
+  };
+  return { provider, lastPrompt: () => lastPrompt };
+}
+
+test.describe('buildFilteredCatalog', () => {
+  test('empty inventory keeps only bodyweight exercises', () => {
+    const filtered = buildFilteredCatalog({});
+    const ids = idsOf(filtered);
+    // Bodyweight-only exercises remain.
+    expect(ids).toContain('warmup-hip-circles');
+    expect(ids).toContain('warmup-worlds-greatest-stretch');
+    expect(ids).toContain('90-90-hip-switch');
+    expect(ids).toContain('cat-cow-spinal-flow');
+    expect(ids).toContain('thread-the-needle');
+    expect(ids).toContain('wall-slides');
+    // swedish-ladder-pushups has equipmentAlternatives: [['bodyweight']]
+    expect(ids).toContain('swedish-ladder-pushups');
+
+    // Equipment-required exercises drop.
+    expect(ids).not.toContain('warmup-band-pull-aparts'); // resistance-band
+    expect(ids).not.toContain('swedish-ladder-dead-hang');
+    expect(ids).not.toContain('kb-gorilla-rows');
+    expect(ids).not.toContain('kettlebell-swings');
+    expect(ids).not.toContain('goblet-squats');
+    expect(ids).not.toContain('trx-inverted-rows');
+    expect(ids).not.toContain('hanging-knee-raises');
+    expect(ids).not.toContain('peloton-hiit-tabata');
+
+    expect(filtered.totalCatalogSize).toBe(
+      Object.keys(EXERCISE_CATALOG).length,
+    );
+    expect(filtered.supportedCount).toBe(filtered.exercises.length);
+  });
+
+  test('kettlebell-only inventory surfaces goblet squats, swings, and KB rows with the owned weight', () => {
+    const inv: Inventory = {
+      kettlebell: { kind: 'kettlebell', ownedWeights: [25] },
+    };
+    const filtered = buildFilteredCatalog(inv);
+    const byId = new Map(filtered.exercises.map((e) => [e.id, e]));
+
+    expect(byId.has('goblet-squats')).toBe(true);
+    expect(byId.get('goblet-squats')?.allowedWeights).toEqual([25]);
+
+    expect(byId.has('kettlebell-swings')).toBe(true);
+    expect(byId.get('kettlebell-swings')?.allowedWeights).toEqual([25]);
+
+    expect(byId.has('kb-gorilla-rows')).toBe(true);
+    expect(byId.get('kb-gorilla-rows')?.allowedWeights).toEqual([25]);
+
+    // TRX exercises still missing.
+    expect(byId.has('trx-inverted-rows')).toBe(false);
+  });
+
+  test('kettlebell + dumbbell unions weights for exercises that accept either', () => {
+    const inv: Inventory = {
+      kettlebell: { kind: 'kettlebell', ownedWeights: [25, 35] },
+      dumbbell: { kind: 'dumbbell', ownedWeights: [10, 15, 20] },
+    };
+    const filtered = buildFilteredCatalog(inv);
+    const byId = new Map(filtered.exercises.map((e) => [e.id, e]));
+
+    expect(byId.get('kb-gorilla-rows')?.allowedWeights).toEqual([
+      10, 15, 20, 25, 35,
+    ]);
+    expect(byId.get('goblet-squats')?.allowedWeights).toEqual([
+      10, 15, 20, 25, 35,
+    ]);
+    // Swings only accepts kettlebell.
+    expect(byId.get('kettlebell-swings')?.allowedWeights).toEqual([25, 35]);
+  });
+
+  test('TRX + swedish-ladder + pullup-bar surfaces unweighted exercises only', () => {
+    const inv: Inventory = {
+      trx: { kind: 'trx', ownedWeights: [] },
+      'swedish-ladder': { kind: 'swedish-ladder', ownedWeights: [] },
+      'pullup-bar': { kind: 'pullup-bar', ownedWeights: [] },
+    };
+    const filtered = buildFilteredCatalog(inv);
+    const byId = new Map(filtered.exercises.map((e) => [e.id, e]));
+
+    expect(byId.has('trx-inverted-rows')).toBe(true);
+    expect(byId.has('swedish-ladder-dead-hang')).toBe(true);
+    expect(byId.has('swedish-ladder-pushups')).toBe(true);
+    expect(byId.has('hanging-knee-raises')).toBe(true);
+
+    // No weighted exercises.
+    expect(byId.has('kettlebell-swings')).toBe(false);
+    expect(byId.has('kb-gorilla-rows')).toBe(false);
+    expect(byId.has('goblet-squats')).toBe(false);
+  });
+});
+
+test.describe('renderPrompt + extractRuntimeTemplate', () => {
+  test('runtime template is extractable and contains all three placeholders', () => {
+    const template = extractRuntimeTemplate(RAW_TEMPLATE);
+    expect(template).toContain('{{user_request}}');
+    expect(template).toContain('{{filtered_catalog_json}}');
+    expect(template).toContain('{{previous_program_or_none}}');
+    // It should NOT contain the manual-fallback content.
+    expect(template).not.toContain('Phase 1: The Foundation');
+  });
+
+  test('renderPrompt substitutes placeholders and embeds the catalog as JSON', () => {
+    const template = extractRuntimeTemplate(RAW_TEMPLATE);
+    const filtered = buildFilteredCatalog({
+      kettlebell: { kind: 'kettlebell', ownedWeights: [25, 35] },
+    });
+    const prompt = renderPrompt({
+      template,
+      userRequest: 'hello',
+      filteredCatalog: filtered,
+    });
+    expect(prompt).toContain('hello');
+    expect(prompt).toContain('"id": "goblet-squats"');
+    expect(prompt).not.toContain('{{user_request}}');
+    expect(prompt).not.toContain('{{filtered_catalog_json}}');
+    expect(prompt).not.toContain('{{previous_program_or_none}}');
+  });
+
+  test('missing markers throw a clear error', () => {
+    expect(() => extractRuntimeTemplate('no markers here')).toThrow(
+      /RUNTIME PROMPT START\/END markers/,
+    );
+  });
+});
+
+test.describe('generateProgramWithTemplate (mocked provider)', () => {
+  test('forwards the filtered catalog into the prompt and excludes unsupported exercises', async () => {
+    const inv: Inventory = {
+      kettlebell: { kind: 'kettlebell', ownedWeights: [25] },
+    };
+    const { provider, lastPrompt } = fakeProvider(() =>
+      JSON.stringify(validProgram('goblet-squats')),
+    );
+    configureProvider(provider);
+
+    await generateProgramWithTemplate(
+      { inventory: inv, userRequest: 'phase one' },
+      RAW_TEMPLATE,
+    );
+
+    const prompt = lastPrompt();
+    expect(prompt).toContain('"id": "goblet-squats"');
+    expect(prompt).toContain('"id": "kettlebell-swings"');
+    // Unsupported exercises must not appear in the prompt.
+    expect(prompt).not.toContain('"id": "trx-inverted-rows"');
+    expect(prompt).not.toContain('"id": "warmup-band-pull-aparts"');
+  });
+
+  test('returns an empty warnings list when the program uses only supported exercises', async () => {
+    const inv: Inventory = {
+      kettlebell: { kind: 'kettlebell', ownedWeights: [25] },
+    };
+    const { provider } = fakeProvider(() =>
+      JSON.stringify(validProgram('goblet-squats')),
+    );
+    configureProvider(provider);
+
+    const result = await generateProgramWithTemplate(
+      { inventory: inv, userRequest: 'phase one' },
+      RAW_TEMPLATE,
+    );
+    expect(result.warnings).toEqual([]);
+    expect(result.program.phases.length).toBe(1);
+    expect(result.filteredCatalog.supportedCount).toBeGreaterThan(0);
+  });
+
+  test('returns warnings when the program references an unsupported exercise', async () => {
+    const inv: Inventory = {
+      kettlebell: { kind: 'kettlebell', ownedWeights: [25] },
+    };
+    // trx-inverted-rows requires TRX, which we do not own.
+    const { provider } = fakeProvider(() =>
+      JSON.stringify(validProgram('trx-inverted-rows')),
+    );
+    configureProvider(provider);
+
+    const result = await generateProgramWithTemplate(
+      { inventory: inv, userRequest: 'phase one' },
+      RAW_TEMPLATE,
+    );
+    expect(result.warnings.length).toBeGreaterThan(0);
+    expect(result.warnings.some((w) => w.message.includes('trx'))).toBe(true);
+  });
+
+  test('non-JSON provider response throws with a clear message', async () => {
+    const { provider } = fakeProvider(() => 'not json at all');
+    configureProvider(provider);
+
+    await expect(
+      generateProgramWithTemplate(
+        { inventory: {}, userRequest: 'phase one' },
+        RAW_TEMPLATE,
+      ),
+    ).rejects.toThrow(/AI returned non-JSON/);
+  });
+
+  test('structurally-broken JSON throws with schema errors in the message', async () => {
+    // Missing meta entirely — schema validator returns errors.
+    const { provider } = fakeProvider(() =>
+      JSON.stringify({ phases: [] }),
+    );
+    configureProvider(provider);
+
+    await expect(
+      generateProgramWithTemplate(
+        { inventory: {}, userRequest: 'phase one' },
+        RAW_TEMPLATE,
+      ),
+    ).rejects.toThrow(/failed schema validation/);
+  });
+
+  test('strips ```json code fences from provider output', async () => {
+    const fenced = '```json\n' + JSON.stringify(validProgram('cat-cow-spinal-flow')) + '\n```';
+    const { provider } = fakeProvider(() => fenced);
+    configureProvider(provider);
+
+    const result = await generateProgramWithTemplate(
+      { inventory: {}, userRequest: 'phase one' },
+      RAW_TEMPLATE,
+    );
+    expect(result.warnings).toEqual([]);
+  });
+});


### PR DESCRIPTION
PR-C is the final of three landing the equipment-inventory feature. PR-A
added the catalog; PR-B added the user inventory and Settings UI. PR-C
makes the planner inventory-aware: it sends a filtered catalog (only
exercises the user can perform) to the LLM and validates the response
against inventory before persistence.

The LLM provider stack is still stubbed in `src/llm/index.ts` — this PR
makes the orchestrator callable; configuring an actual BYOK / local
provider remains a separate workstream per the umbrella plan.

## What changed

- `src/llm/programGen.ts` + `src/llm/programGenCore.ts`: new orchestrator.
  Builds a filtered catalog from the active inventory, renders the
  runtime prompt template, invokes `generate()`, parses JSON, and
  validates the response against the catalog + inventory. Hard schema
  errors throw; inventory mismatches flow back as warnings.
- `prompts/generate-phase.md`: renamed from `phases.md`. Adds the
  `RUNTIME PROMPT START` / `END` template the orchestrator embeds, with
  the existing manual paste-into-an-AI content preserved below the
  divider for users without a configured provider.
- `src/tabs/Workouts/index.tsx` + new `GenerateAIModal`: replaces the
  permanently-disabled "Generate with AI (soon)" button. When the
  provider is unavailable the button stays disabled with a "configure
  in Settings" tooltip; when available it opens a modal that collects a
  free-form request, shows a loading state, presents a review screen
  (phase count, exercise count, friendly warning list), and persists
  via `saveProgram`.
- `src/main.tsx`: exposes a `window.flux_test_configureLLM` hook so
  Playwright tests can inject a fake provider end-to-end.
- Tests: 13 new unit tests (catalog filtering, prompt rendering,
  orchestrator with mocked provider) and 4 new e2e tests (button
  gating, full modal flow, drift warnings, error/retry).

## Test plan

- [x] `nix develop --command npm run typecheck` clean
- [x] `nix develop --command npm run build` clean
- [x] `nix develop .#test --command npm test` — 53/53 pass
- [x] `klaus _pre-review` — no critical/high findings
- [x] Generate button shows "configure in Settings" when no provider available
- [x] Warnings render on the review screen when inventory mismatch
- [x] Manual `prompts/generate-phase.md` content still usable for paste-into-Claude workflow (preserved verbatim below the runtime template divider)

Run: 20260529-1730-58c585b6